### PR TITLE
Gummyroll

### DIFF
--- a/merkle-accumulator/src/main.rs
+++ b/merkle-accumulator/src/main.rs
@@ -182,14 +182,6 @@ impl MerkleAccumulator {
         for i in 0..self.buffer_size {
             let j = self.active_index.wrapping_sub(i) & MASK;
             if self.roots[j] != current_root {
-<<<<<<< HEAD
-                /*
-                if self.change_logs[j].changes[MAX_DEPTH - 1] == leaf {
-                    return None;
-                }
-                */
-=======
->>>>>>> bcb8cbe6b4ad9a989d3a2b0eae1fae2845c5d8b3
                 continue;
             }
             let old_root = recompute(leaf, &proof, index);

--- a/merkle-accumulator/src/main.rs
+++ b/merkle-accumulator/src/main.rs
@@ -99,9 +99,11 @@ impl MerkleAccumulator {
             let j = self.active_index.wrapping_sub(i) & MASK;
 
             if self.roots[j] != current_root {
+                /*
                 if self.change_logs[j].changes[MAX_DEPTH - 1] == leaf {
                     return None;
                 }
+                */
                 continue;
             }
             let old_root = recompute(leaf, &proof, path);

--- a/merkle-accumulator/src/merkle.rs
+++ b/merkle-accumulator/src/merkle.rs
@@ -5,12 +5,13 @@ use std::iter::FromIterator;
 use std::rc::Rc;
 
 pub type Node = [u8; 32];
+pub const EMPTY: Node = [0; 32];
 
 /// Max number of concurrent changes to tree supported before having to regenerate proofs
 pub const MAX_SIZE: usize = 64;
 
 /// Max depth of the Merkle tree
-pub const MAX_DEPTH: usize = 10;
+pub const MAX_DEPTH: usize = 14;
 
 pub const PADDING: usize = 32 - MAX_DEPTH;
 
@@ -64,7 +65,7 @@ impl MerkleTree {
             } else {
                 tree.pop_front().unwrap()
             };
-            let mut hashed_parent = [0; 32];
+            let mut hashed_parent = EMPTY;
 
             hashed_parent
                 .copy_from_slice(hashv(&[&left.borrow().node, &right.borrow().node]).as_ref());
@@ -147,7 +148,7 @@ impl MerkleTree {
     }
 
     pub fn remove_leaf(&mut self, leaf_idx: usize) {
-        self.leaf_nodes[leaf_idx].borrow_mut().node = [0; 32];
+        self.leaf_nodes[leaf_idx].borrow_mut().node = EMPTY;
         self.update_root_from_leaf(leaf_idx)
     }
 }
@@ -202,7 +203,7 @@ impl TreeNode {
 /// Calculates hash of empty nodes up to level i
 /// TODO: cache this
 pub fn empty_node(level: u32) -> Node {
-    let mut data = [0; 32];
+    let mut data = EMPTY;
     if level != 0 {
         let lower_empty = empty_node(level - 1);
         let hash = hashv(&[&lower_empty, &lower_empty]);

--- a/tests/gummyroll.ts
+++ b/tests/gummyroll.ts
@@ -14,7 +14,7 @@ import { PublicKey, Keypair, SystemProgram, Transaction } from "@solana/web3.js"
 import { Token, ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { assert } from "chai";
 
-import { buildTree, hash, getProofOfLeaf, updateTree, hashLeaves } from './merkle-tree';
+import { MAX_SIZE, buildTree, hash, getProofOfLeaf, updateTree, hashLeaves } from './merkle-tree';
 
 const TOKEN_PROGRAM_2022_ID = new PublicKey(
   "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
@@ -27,6 +27,11 @@ const logTx = async (provider, tx) => {
       .logMessages
   );
 };
+
+async function checkTxStatus(provider: anchor.Provider, tx: string): Promise<boolean> {
+  let metaTx = await provider.connection.getTransaction(tx, { commitment: "confirmed" });
+  return metaTx.meta.err === null;
+}
 
 describe("gummyroll", () => {
   // Configure the client to use the local cluster.
@@ -76,7 +81,6 @@ describe("gummyroll", () => {
             signers: [payer],
         }
     );
-    // console.log("init gummy roll ix:", initGummyrollIx);
 
     const tx = new Transaction().add(allocAccountIx).add(initGummyrollIx);
     let txid = await program.provider.send(tx, [payer, merkleRollKeypair], {
@@ -84,12 +88,9 @@ describe("gummyroll", () => {
     })
     await logTx(program.provider, txid);
     const merkleRoll = await program.account.merkleRoll.fetch(merkleRollKeypair.publicKey);
-    // console.log("Loaded merkleRoll...");
-    // console.log("            root:", Buffer.from(merkleRoll.roots[0].inner));
-    // console.log("       expecting:", tree.root);
     assert(
+        Buffer.from(merkleRoll.roots[0].inner).equals(tree.root),
         "On chain root matches root passed in instruction", 
-        Buffer.from(merkleRoll.roots[0].inner) === tree.root
     );
   });
   it("Replace single leaf", async () => {
@@ -97,18 +98,8 @@ describe("gummyroll", () => {
     const newLeaf = hash(payer.publicKey.toBuffer(), payer.publicKey.toBuffer());
     const index = 2;
     const proof = getProofOfLeaf(tree, index);
-    // console.log("typescript path: ", path);
-    // console.log("proof:", proof);
-
-    const recomputed = hashLeaves(tree.leaves.map((node) => {return node.node}));
-    console.log("Recomputed matches root?");
-    console.log("             Recomputed:", recomputed);
-    console.log("                   Root:", tree.root);
 
     const nodeProof = proof.map((treeNode) => { return { inner: treeNode.node }});
-    console.log("nodeProof:", nodeProof.map((node) => { return node.inner } ));
-
-    // updateTree(tree, newLeaf, index);
 
     const replaceLeafIx = await program.instruction.replaceLeaf(
         { inner: Array.from(tree.root) },
@@ -124,7 +115,6 @@ describe("gummyroll", () => {
             signers: [payer],
         }
     );
-    // console.log("Replace leaf ix:", replaceLeafIx);
 
     const tx = new Transaction().add(replaceLeafIx);
     const txid = await program.provider.send(tx, [payer], {
@@ -132,30 +122,26 @@ describe("gummyroll", () => {
     });
     logTx(program.provider, txid);
 
+    updateTree(tree, newLeaf, index);
+
     const merkleRoll = await program.account.merkleRoll.fetch(merkleRollKeypair.publicKey);
     const onChainRoot = merkleRoll.roots[merkleRoll.activeIndex.toNumber()].inner;
-    // console.log("Merkle roll loaded...");
-    // console.log("       root:", onChainRoot);
-    // console.log("   expected:", tree.root);
 
     assert(
+        Buffer.from(onChainRoot).equals(tree.root),
         "Updated on chain root matches root of updated off chain tree", 
-        Buffer.from(onChainRoot) === tree.root
     );
   });
-  it.skip("Replace leaf - max block (64)", async () => {
+  it("Replace leaf - max block (64)", async () => {
     /// Replace 64 leaves before syncing off-chain tree with on-chain tree
 
     let changeArray = [];
-    for(let i = 0; i < 64; i++) {
+    let txList = [];
+
+    for(let i = 0; i < MAX_SIZE; i++) {
         const index = 3+i;
         const newLeaf = hash(payer.publicKey.toBuffer(), Buffer.from(new BN(i).toArray()));
         const proof = getProofOfLeaf(tree, index);
-        // const recomputed = hashLeaves(tree.leaves.map((node) => {return node.node}));
-        // console.log("Recomputed matches root?");
-        // console.log("             Recomputed:", recomputed);
-        // console.log("                   Root:", tree.root);
-        // console.log("Proof: ", proof);
 
         /// Use this to sync off-chain tree
         changeArray.push({newLeaf, index});
@@ -178,24 +164,72 @@ describe("gummyroll", () => {
         );
 
         const tx = new Transaction().add(replaceLeafIx);
-        const txid = await program.provider.send(tx, [payer], {
-            commitment: 'confirmed',
-        });
-        logTx(program.provider, txid);
+        txList.push(
+            program.provider.send(tx, [payer], {
+                commitment: 'confirmed',
+            })
+            .then((txId) => checkTxStatus(program.provider, txId))
+            .then((txOk) => { if (!txOk) { throw Error("Encountered failed tx")} })
+        );
     }
+    await Promise.all(txList);
 
     changeArray.forEach((change) => {
         updateTree(tree, change.newLeaf, change.index);
     })
     const merkleRoll = await program.account.merkleRoll.fetch(merkleRollKeypair.publicKey);
     const onChainRoot = merkleRoll.roots[merkleRoll.activeIndex.toNumber()].inner;
-    console.log("Merkle roll loaded...");
-    console.log("       root:", onChainRoot);
-    console.log("   expected:", tree.root);
-    
     assert(
+        Buffer.from(onChainRoot).equals(tree.root),
         "Updated on chain root matches root of updated off chain tree", 
-        Buffer.from(onChainRoot) === tree.root
     );
+  });
+  it("Replace leaf - max block + 1 (65)", async () => {
+    /// Replace more leaves than MAX_SIZE, which should fail
+
+    let changeArray = [];
+    let txList = [];
+
+    const offset = 3+MAX_SIZE;
+    for(let i = 0; i < MAX_SIZE+1; i++) {
+        const index = offset+i;
+        const newLeaf = hash(payer.publicKey.toBuffer(), Buffer.from(new BN(i).toArray()));
+        const proof = getProofOfLeaf(tree, index);
+
+        /// Use this to sync off-chain tree
+        changeArray.push({newLeaf, index});
+
+        const nodeProof = proof.map((treeNode) => { return { inner: treeNode.node } });
+
+        const replaceLeafIx = await program.instruction.replaceLeaf(
+            { inner: Array.from(tree.root) },
+            { inner: Array.from(Buffer.alloc(32)) },
+            { inner: Array.from(newLeaf) },
+            nodeProof,
+            index,
+            {
+                accounts: {
+                    merkleRoll: merkleRollKeypair.publicKey,
+                    payer: payer.publicKey,
+                },
+                signers: [payer],
+            }
+        );
+
+        const tx = new Transaction().add(replaceLeafIx);
+        txList.push(
+            program.provider.send(tx, [payer], {
+                commitment: 'confirmed',
+            })
+            .then((txId) => checkTxStatus(program.provider, txId))
+            .catch(() => {return false})
+        );
+    }
+    let txIds = await Promise.all(txList)
+    let failures = txIds.map((txOk) => Number(!txOk)).reduce(
+        (left, right) => left + right,
+        0
+    );
+    assert(failures === 1, "Exactly 1 failure");
   });
 });

--- a/tests/merkle-tree.ts
+++ b/tests/merkle-tree.ts
@@ -102,8 +102,6 @@ export function buildTree(leaves: Buffer[]): Tree {
         seqNum++;
     }
 
-    console.log("LEVEL:", nodes.peek().level);
-
     return {
         root: nodes.peek().node,
         leaves: finalLeaves,
@@ -118,58 +116,35 @@ export function getProofOfLeaf(tree: Tree, idx: number): TreeNode[] {
 
     let node = tree.leaves[idx];
 
-    console.log("Start");
-    console.log(Uint8Array.from(node.node));
     while (typeof node.parent !== 'undefined') {
         let parent = node.parent;
         if (parent.left.id === node.id) {
             proof.push(parent.right);
+
             if (hash(node.node, parent.right.node) !== parent.node) {
-                console.log("fuck 0");
+                throw new Error("Invariant broken when hashing left node")
             }
         } else {
             proof.push(parent.left);
+
             if (hash(node.node, parent.right.node) !== parent.node) {
-                console.log("fuck 1");
+                throw new Error("Invariant broken when hashing right node")
             }
         }
-        console.log(Uint8Array.from(parent.node));
         node = parent;
     }
-    console.log("Proof length:", proof.length);
 
     return proof;
 }
 
-// export function hashProof(path: number, leaf: TreeNode, proof: TreeNode[]) {
-//     // let isLeft = proof[0].parent.left.id === leaf.id;
-//     // let start: Buffer = isLeft ? hash(leaf.node, proof[0].node) : hash(proof[0].node, leaf.node);
-//     let start = leaf.node;
-
-//     proof.forEach((node, idx) => {
-//         if (idx == 0) { return }
-        
-//         if (proof[idx - 1].id === node.left.id) {
-//             start = hash(node.node,)
-//         }
-
-//         if (isLeft) {
-//             start = hash(leaf, )
-//         }
-//     })
-//     return start;
-// }
-
 export function updateTree(tree: Tree, newNode: Buffer, index: number) {
     let leaf = tree.leaves[index];
     leaf.node = newNode;
-    console.log("Leaf: ", Uint8Array.from(leaf.node));
     let node = leaf.parent;
 
     var i = 0;
     while (typeof node.parent !== 'undefined') {
         node.node = hash(node.left.node, node.right.node);
-        console.log(`${i}: `, Uint8Array.from(node.node));
         node = node.parent;
         i++;
     }


### PR DESCRIPTION
Merge `append` instruction

Clarify instruction primitives & when write-conflicts should be handled beyond failing (only when fill_or_append is called with a proof to a leaf node that was previously empty)