### PR TITLE
A high level program that can be used to append/transfer/remove a message

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,6 +1,7 @@
 [programs.localnet]
 merkle_wallet = "4KgH7kNwAzaR26MiwXcdWstZogQCYNryPL1s7herTkov"
 gummyroll = "GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD"
+gummyroll_crud = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [[test.genesis]]
 address = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
     "programs/merkle_wallet",
     "programs/gummyroll",
+    "programs/gummyroll_crud",
     "merkle-accumulator"
 ]

--- a/programs/gummyroll/src/lib.rs
+++ b/programs/gummyroll/src/lib.rs
@@ -36,72 +36,72 @@ macro_rules! merkle_roll_depth_size_apply_fn {
 macro_rules! merkle_roll_apply_fn {
     ($header:ident, $bytes:ident, $func:ident, $($arg:tt)*) => {
         match ($header.max_depth, $header.max_buffer_size) {
-            (14, 64) => merkle_roll_depth_size_apply_fn!(14, 64, $bytes, $func, $($arg)*),
-            (14, 128) => merkle_roll_depth_size_apply_fn!(14, 128, $bytes, $func, $($arg)*),
-            (14, 256) => merkle_roll_depth_size_apply_fn!(14, 256, $bytes, $func, $($arg)*),
-            (14, 512) => merkle_roll_depth_size_apply_fn!(14, 512, $bytes, $func, $($arg)*),
-            (14, 1024) => merkle_roll_depth_size_apply_fn!(14, 1024, $bytes, $func, $($arg)*),
-            (14, 2448) => merkle_roll_depth_size_apply_fn!(14, 2448, $bytes, $func, $($arg)*),
-            (15, 64) => merkle_roll_depth_size_apply_fn!(15, 64, $bytes, $func, $($arg)*),
-            (15, 128) => merkle_roll_depth_size_apply_fn!(15, 128, $bytes, $func, $($arg)*),
-            (15, 256) => merkle_roll_depth_size_apply_fn!(15, 256, $bytes, $func, $($arg)*),
-            (15, 512) => merkle_roll_depth_size_apply_fn!(15, 512, $bytes, $func, $($arg)*),
-            (15, 1024) => merkle_roll_depth_size_apply_fn!(15, 1024, $bytes, $func, $($arg)*),
-            (15, 2448) => merkle_roll_depth_size_apply_fn!(15, 2448, $bytes, $func, $($arg)*),
-            (16, 64) => merkle_roll_depth_size_apply_fn!(16, 64, $bytes, $func, $($arg)*),
-            (16, 128) => merkle_roll_depth_size_apply_fn!(16, 128, $bytes, $func, $($arg)*),
-            (16, 256) => merkle_roll_depth_size_apply_fn!(16, 256, $bytes, $func, $($arg)*),
-            (16, 512) => merkle_roll_depth_size_apply_fn!(16, 512, $bytes, $func, $($arg)*),
-            (16, 1024) => merkle_roll_depth_size_apply_fn!(16, 1024, $bytes, $func, $($arg)*),
-            (16, 2448) => merkle_roll_depth_size_apply_fn!(16, 2448, $bytes, $func, $($arg)*),
-            (17, 64) => merkle_roll_depth_size_apply_fn!(17, 64, $bytes, $func, $($arg)*),
-            (17, 128) => merkle_roll_depth_size_apply_fn!(17, 128, $bytes, $func, $($arg)*),
-            (17, 256) => merkle_roll_depth_size_apply_fn!(17, 256, $bytes, $func, $($arg)*),
-            (17, 512) => merkle_roll_depth_size_apply_fn!(17, 512, $bytes, $func, $($arg)*),
-            (17, 1024) => merkle_roll_depth_size_apply_fn!(17, 1024, $bytes, $func, $($arg)*),
-            (17, 2448) => merkle_roll_depth_size_apply_fn!(17, 2448, $bytes, $func, $($arg)*),
-            (18, 64) => merkle_roll_depth_size_apply_fn!(18, 64, $bytes, $func, $($arg)*),
-            (18, 128) => merkle_roll_depth_size_apply_fn!(18, 128, $bytes, $func, $($arg)*),
-            (18, 256) => merkle_roll_depth_size_apply_fn!(18, 256, $bytes, $func, $($arg)*),
-            (18, 512) => merkle_roll_depth_size_apply_fn!(18, 512, $bytes, $func, $($arg)*),
-            (18, 1024) => merkle_roll_depth_size_apply_fn!(18, 1024, $bytes, $func, $($arg)*),
-            (18, 2448) => merkle_roll_depth_size_apply_fn!(18, 2448, $bytes, $func, $($arg)*),
-            (19, 64) => merkle_roll_depth_size_apply_fn!(19, 64, $bytes, $func, $($arg)*),
-            (19, 128) => merkle_roll_depth_size_apply_fn!(19, 128, $bytes, $func, $($arg)*),
-            (19, 256) => merkle_roll_depth_size_apply_fn!(19, 256, $bytes, $func, $($arg)*),
-            (19, 512) => merkle_roll_depth_size_apply_fn!(19, 512, $bytes, $func, $($arg)*),
-            (19, 1024) => merkle_roll_depth_size_apply_fn!(19, 1024, $bytes, $func, $($arg)*),
-            (19, 2448) => merkle_roll_depth_size_apply_fn!(19, 2448, $bytes, $func, $($arg)*),
+            // (14, 64) => merkle_roll_depth_size_apply_fn!(14, 64, $bytes, $func, $($arg)*),
+            // (14, 128) => merkle_roll_depth_size_apply_fn!(14, 128, $bytes, $func, $($arg)*),
+            // (14, 256) => merkle_roll_depth_size_apply_fn!(14, 256, $bytes, $func, $($arg)*),
+            // (14, 512) => merkle_roll_depth_size_apply_fn!(14, 512, $bytes, $func, $($arg)*),
+            // (14, 1024) => merkle_roll_depth_size_apply_fn!(14, 1024, $bytes, $func, $($arg)*),
+            // (14, 2448) => merkle_roll_depth_size_apply_fn!(14, 2448, $bytes, $func, $($arg)*),
+            // (15, 64) => merkle_roll_depth_size_apply_fn!(15, 64, $bytes, $func, $($arg)*),
+            // (15, 128) => merkle_roll_depth_size_apply_fn!(15, 128, $bytes, $func, $($arg)*),
+            // (15, 256) => merkle_roll_depth_size_apply_fn!(15, 256, $bytes, $func, $($arg)*),
+            // (15, 512) => merkle_roll_depth_size_apply_fn!(15, 512, $bytes, $func, $($arg)*),
+            // (15, 1024) => merkle_roll_depth_size_apply_fn!(15, 1024, $bytes, $func, $($arg)*),
+            // (15, 2448) => merkle_roll_depth_size_apply_fn!(15, 2448, $bytes, $func, $($arg)*),
+            // (16, 64) => merkle_roll_depth_size_apply_fn!(16, 64, $bytes, $func, $($arg)*),
+            // (16, 128) => merkle_roll_depth_size_apply_fn!(16, 128, $bytes, $func, $($arg)*),
+            // (16, 256) => merkle_roll_depth_size_apply_fn!(16, 256, $bytes, $func, $($arg)*),
+            // (16, 512) => merkle_roll_depth_size_apply_fn!(16, 512, $bytes, $func, $($arg)*),
+            // (16, 1024) => merkle_roll_depth_size_apply_fn!(16, 1024, $bytes, $func, $($arg)*),
+            // (16, 2448) => merkle_roll_depth_size_apply_fn!(16, 2448, $bytes, $func, $($arg)*),
+            // (17, 64) => merkle_roll_depth_size_apply_fn!(17, 64, $bytes, $func, $($arg)*),
+            // (17, 128) => merkle_roll_depth_size_apply_fn!(17, 128, $bytes, $func, $($arg)*),
+            // (17, 256) => merkle_roll_depth_size_apply_fn!(17, 256, $bytes, $func, $($arg)*),
+            // (17, 512) => merkle_roll_depth_size_apply_fn!(17, 512, $bytes, $func, $($arg)*),
+            // (17, 1024) => merkle_roll_depth_size_apply_fn!(17, 1024, $bytes, $func, $($arg)*),
+            // (17, 2448) => merkle_roll_depth_size_apply_fn!(17, 2448, $bytes, $func, $($arg)*),
+            // (18, 64) => merkle_roll_depth_size_apply_fn!(18, 64, $bytes, $func, $($arg)*),
+            // (18, 128) => merkle_roll_depth_size_apply_fn!(18, 128, $bytes, $func, $($arg)*),
+            // (18, 256) => merkle_roll_depth_size_apply_fn!(18, 256, $bytes, $func, $($arg)*),
+            // (18, 512) => merkle_roll_depth_size_apply_fn!(18, 512, $bytes, $func, $($arg)*),
+            // (18, 1024) => merkle_roll_depth_size_apply_fn!(18, 1024, $bytes, $func, $($arg)*),
+            // (18, 2448) => merkle_roll_depth_size_apply_fn!(18, 2448, $bytes, $func, $($arg)*),
+            // (19, 64) => merkle_roll_depth_size_apply_fn!(19, 64, $bytes, $func, $($arg)*),
+            // (19, 128) => merkle_roll_depth_size_apply_fn!(19, 128, $bytes, $func, $($arg)*),
+            // (19, 256) => merkle_roll_depth_size_apply_fn!(19, 256, $bytes, $func, $($arg)*),
+            // (19, 512) => merkle_roll_depth_size_apply_fn!(19, 512, $bytes, $func, $($arg)*),
+            // (19, 1024) => merkle_roll_depth_size_apply_fn!(19, 1024, $bytes, $func, $($arg)*),
+            // (19, 2448) => merkle_roll_depth_size_apply_fn!(19, 2448, $bytes, $func, $($arg)*),
             (20, 64) => merkle_roll_depth_size_apply_fn!(20, 64, $bytes, $func, $($arg)*),
             (20, 128) => merkle_roll_depth_size_apply_fn!(20, 128, $bytes, $func, $($arg)*),
             (20, 256) => merkle_roll_depth_size_apply_fn!(20, 256, $bytes, $func, $($arg)*),
             (20, 512) => merkle_roll_depth_size_apply_fn!(20, 512, $bytes, $func, $($arg)*),
             (20, 1024) => merkle_roll_depth_size_apply_fn!(20, 1024, $bytes, $func, $($arg)*),
             (20, 2448) => merkle_roll_depth_size_apply_fn!(20, 2448, $bytes, $func, $($arg)*),
-            (21, 64) => merkle_roll_depth_size_apply_fn!(21, 64, $bytes, $func, $($arg)*),
-            (21, 128) => merkle_roll_depth_size_apply_fn!(21, 128, $bytes, $func, $($arg)*),
-            (21, 256) => merkle_roll_depth_size_apply_fn!(21, 256, $bytes, $func, $($arg)*),
-            (21, 512) => merkle_roll_depth_size_apply_fn!(21, 512, $bytes, $func, $($arg)*),
-            (21, 1024) => merkle_roll_depth_size_apply_fn!(21, 1024, $bytes, $func, $($arg)*),
-            (21, 2448) => merkle_roll_depth_size_apply_fn!(21, 2448, $bytes, $func, $($arg)*),
-            (22, 64) => merkle_roll_depth_size_apply_fn!(22, 64, $bytes, $func, $($arg)*),
-            (22, 128) => merkle_roll_depth_size_apply_fn!(22, 128, $bytes, $func, $($arg)*),
-            (22, 256) => merkle_roll_depth_size_apply_fn!(22, 256, $bytes, $func, $($arg)*),
-            (22, 512) => merkle_roll_depth_size_apply_fn!(22, 512, $bytes, $func, $($arg)*),
-            (22, 1024) => merkle_roll_depth_size_apply_fn!(22, 1024, $bytes, $func, $($arg)*),
-            (22, 2448) => merkle_roll_depth_size_apply_fn!(22, 2448, $bytes, $func, $($arg)*),
-            (23, 64) => merkle_roll_depth_size_apply_fn!(23, 64, $bytes, $func, $($arg)*),
-            (23, 128) => merkle_roll_depth_size_apply_fn!(23, 128, $bytes, $func, $($arg)*),
-            (23, 256) => merkle_roll_depth_size_apply_fn!(23, 256, $bytes, $func, $($arg)*),
-            (23, 512) => merkle_roll_depth_size_apply_fn!(23, 512, $bytes, $func, $($arg)*),
-            (23, 1024) => merkle_roll_depth_size_apply_fn!(23, 1024, $bytes, $func, $($arg)*),
-            (23, 2448) => merkle_roll_depth_size_apply_fn!(23, 2448, $bytes, $func, $($arg)*),
-            (24, 64) => merkle_roll_depth_size_apply_fn!(24, 64, $bytes, $func, $($arg)*),
-            (24, 128) => merkle_roll_depth_size_apply_fn!(24, 128, $bytes, $func, $($arg)*),
-            (24, 256) => merkle_roll_depth_size_apply_fn!(24, 256, $bytes, $func, $($arg)*),
-            (24, 512) => merkle_roll_depth_size_apply_fn!(24, 512, $bytes, $func, $($arg)*),
-            (24, 1024) => merkle_roll_depth_size_apply_fn!(24, 1024, $bytes, $func, $($arg)*),
-            (24, 2448) => merkle_roll_depth_size_apply_fn!(24, 2448, $bytes, $func, $($arg)*),
+            // (21, 64) => merkle_roll_depth_size_apply_fn!(21, 64, $bytes, $func, $($arg)*),
+            // (21, 128) => merkle_roll_depth_size_apply_fn!(21, 128, $bytes, $func, $($arg)*),
+            // (21, 256) => merkle_roll_depth_size_apply_fn!(21, 256, $bytes, $func, $($arg)*),
+            // (21, 512) => merkle_roll_depth_size_apply_fn!(21, 512, $bytes, $func, $($arg)*),
+            // (21, 1024) => merkle_roll_depth_size_apply_fn!(21, 1024, $bytes, $func, $($arg)*),
+            // (21, 2448) => merkle_roll_depth_size_apply_fn!(21, 2448, $bytes, $func, $($arg)*),
+            // (22, 64) => merkle_roll_depth_size_apply_fn!(22, 64, $bytes, $func, $($arg)*),
+            // (22, 128) => merkle_roll_depth_size_apply_fn!(22, 128, $bytes, $func, $($arg)*),
+            // (22, 256) => merkle_roll_depth_size_apply_fn!(22, 256, $bytes, $func, $($arg)*),
+            // (22, 512) => merkle_roll_depth_size_apply_fn!(22, 512, $bytes, $func, $($arg)*),
+            // (22, 1024) => merkle_roll_depth_size_apply_fn!(22, 1024, $bytes, $func, $($arg)*),
+            // (22, 2448) => merkle_roll_depth_size_apply_fn!(22, 2448, $bytes, $func, $($arg)*),
+            // (23, 64) => merkle_roll_depth_size_apply_fn!(23, 64, $bytes, $func, $($arg)*),
+            // (23, 128) => merkle_roll_depth_size_apply_fn!(23, 128, $bytes, $func, $($arg)*),
+            // (23, 256) => merkle_roll_depth_size_apply_fn!(23, 256, $bytes, $func, $($arg)*),
+            // (23, 512) => merkle_roll_depth_size_apply_fn!(23, 512, $bytes, $func, $($arg)*),
+            // (23, 1024) => merkle_roll_depth_size_apply_fn!(23, 1024, $bytes, $func, $($arg)*),
+            // (23, 2448) => merkle_roll_depth_size_apply_fn!(23, 2448, $bytes, $func, $($arg)*),
+            // (24, 64) => merkle_roll_depth_size_apply_fn!(24, 64, $bytes, $func, $($arg)*),
+            // (24, 128) => merkle_roll_depth_size_apply_fn!(24, 128, $bytes, $func, $($arg)*),
+            // (24, 256) => merkle_roll_depth_size_apply_fn!(24, 256, $bytes, $func, $($arg)*),
+            // (24, 512) => merkle_roll_depth_size_apply_fn!(24, 512, $bytes, $func, $($arg)*),
+            // (24, 1024) => merkle_roll_depth_size_apply_fn!(24, 1024, $bytes, $func, $($arg)*),
+            // (24, 2448) => merkle_roll_depth_size_apply_fn!(24, 2448, $bytes, $func, $($arg)*),
             _ => {
                 msg!("Failed to apply {} on merkle roll with max depth {} and max buffer size {}", stringify!($func), $header.max_depth, $header.max_buffer_size);
                 None
@@ -779,19 +779,24 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
         let root = change_log.recompute_path(start, proof);
 
         emit!(change_log.to_event());
-        if index < self.rightmost_proof.index as u32 {
-            if index != self.rightmost_proof.index - 1 {
-                let common_path_len = ((index ^ (self.rightmost_proof.index - 1) as u32) << padding)
-                    .leading_zeros() as usize;
-                let critbit_index = (MAX_DEPTH - 1) - common_path_len;
-                self.rightmost_proof.proof[critbit_index] = change_log.path[critbit_index];
+
+        // Update rightmost path if possible
+        if self.rightmost_proof.index < (1 << MAX_DEPTH) {
+            if index < self.rightmost_proof.index as u32 {
+                if index != self.rightmost_proof.index - 1 {
+                    let common_path_len = ((index ^ (self.rightmost_proof.index - 1) as u32) << padding)
+                        .leading_zeros() as usize;
+                    msg!("Common path len {}", common_path_len);
+                    let critbit_index = (MAX_DEPTH - 1) - common_path_len;
+                    self.rightmost_proof.proof[critbit_index] = change_log.path[critbit_index];
+                }
+            } else {
+                assert!(index == self.rightmost_proof.index);
+                msg!("Appending rightmost leaf");
+                self.rightmost_proof.proof.copy_from_slice(&proof);
+                self.rightmost_proof.index = index + 1;
+                self.rightmost_proof.leaf = change_log.get_leaf();
             }
-        } else {
-            assert!(index == self.rightmost_proof.index);
-            msg!("Appending rightmost leaf");
-            self.rightmost_proof.proof.copy_from_slice(&proof);
-            self.rightmost_proof.index = index + 1;
-            self.rightmost_proof.leaf = change_log.get_leaf();
         }
         root
     }

--- a/programs/gummyroll/src/lib.rs
+++ b/programs/gummyroll/src/lib.rs
@@ -36,72 +36,26 @@ macro_rules! merkle_roll_depth_size_apply_fn {
 macro_rules! merkle_roll_apply_fn {
     ($header:ident, $bytes:ident, $func:ident, $($arg:tt)*) => {
         match ($header.max_depth, $header.max_buffer_size) {
-            // (14, 64) => merkle_roll_depth_size_apply_fn!(14, 64, $bytes, $func, $($arg)*),
-            // (14, 128) => merkle_roll_depth_size_apply_fn!(14, 128, $bytes, $func, $($arg)*),
-            // (14, 256) => merkle_roll_depth_size_apply_fn!(14, 256, $bytes, $func, $($arg)*),
-            // (14, 512) => merkle_roll_depth_size_apply_fn!(14, 512, $bytes, $func, $($arg)*),
-            // (14, 1024) => merkle_roll_depth_size_apply_fn!(14, 1024, $bytes, $func, $($arg)*),
-            // (14, 2448) => merkle_roll_depth_size_apply_fn!(14, 2448, $bytes, $func, $($arg)*),
-            // (15, 64) => merkle_roll_depth_size_apply_fn!(15, 64, $bytes, $func, $($arg)*),
-            // (15, 128) => merkle_roll_depth_size_apply_fn!(15, 128, $bytes, $func, $($arg)*),
-            // (15, 256) => merkle_roll_depth_size_apply_fn!(15, 256, $bytes, $func, $($arg)*),
-            // (15, 512) => merkle_roll_depth_size_apply_fn!(15, 512, $bytes, $func, $($arg)*),
-            // (15, 1024) => merkle_roll_depth_size_apply_fn!(15, 1024, $bytes, $func, $($arg)*),
-            // (15, 2448) => merkle_roll_depth_size_apply_fn!(15, 2448, $bytes, $func, $($arg)*),
-            // (16, 64) => merkle_roll_depth_size_apply_fn!(16, 64, $bytes, $func, $($arg)*),
-            // (16, 128) => merkle_roll_depth_size_apply_fn!(16, 128, $bytes, $func, $($arg)*),
-            // (16, 256) => merkle_roll_depth_size_apply_fn!(16, 256, $bytes, $func, $($arg)*),
-            // (16, 512) => merkle_roll_depth_size_apply_fn!(16, 512, $bytes, $func, $($arg)*),
-            // (16, 1024) => merkle_roll_depth_size_apply_fn!(16, 1024, $bytes, $func, $($arg)*),
-            // (16, 2448) => merkle_roll_depth_size_apply_fn!(16, 2448, $bytes, $func, $($arg)*),
-            // (17, 64) => merkle_roll_depth_size_apply_fn!(17, 64, $bytes, $func, $($arg)*),
-            // (17, 128) => merkle_roll_depth_size_apply_fn!(17, 128, $bytes, $func, $($arg)*),
-            // (17, 256) => merkle_roll_depth_size_apply_fn!(17, 256, $bytes, $func, $($arg)*),
-            // (17, 512) => merkle_roll_depth_size_apply_fn!(17, 512, $bytes, $func, $($arg)*),
-            // (17, 1024) => merkle_roll_depth_size_apply_fn!(17, 1024, $bytes, $func, $($arg)*),
-            // (17, 2448) => merkle_roll_depth_size_apply_fn!(17, 2448, $bytes, $func, $($arg)*),
-            // (18, 64) => merkle_roll_depth_size_apply_fn!(18, 64, $bytes, $func, $($arg)*),
-            // (18, 128) => merkle_roll_depth_size_apply_fn!(18, 128, $bytes, $func, $($arg)*),
-            // (18, 256) => merkle_roll_depth_size_apply_fn!(18, 256, $bytes, $func, $($arg)*),
-            // (18, 512) => merkle_roll_depth_size_apply_fn!(18, 512, $bytes, $func, $($arg)*),
-            // (18, 1024) => merkle_roll_depth_size_apply_fn!(18, 1024, $bytes, $func, $($arg)*),
-            // (18, 2448) => merkle_roll_depth_size_apply_fn!(18, 2448, $bytes, $func, $($arg)*),
-            // (19, 64) => merkle_roll_depth_size_apply_fn!(19, 64, $bytes, $func, $($arg)*),
-            // (19, 128) => merkle_roll_depth_size_apply_fn!(19, 128, $bytes, $func, $($arg)*),
-            // (19, 256) => merkle_roll_depth_size_apply_fn!(19, 256, $bytes, $func, $($arg)*),
-            // (19, 512) => merkle_roll_depth_size_apply_fn!(19, 512, $bytes, $func, $($arg)*),
-            // (19, 1024) => merkle_roll_depth_size_apply_fn!(19, 1024, $bytes, $func, $($arg)*),
-            // (19, 2448) => merkle_roll_depth_size_apply_fn!(19, 2448, $bytes, $func, $($arg)*),
+            (14, 64) => merkle_roll_depth_size_apply_fn!(14, 64, $bytes, $func, $($arg)*),
+            (14, 256) => merkle_roll_depth_size_apply_fn!(14, 256, $bytes, $func, $($arg)*),
+            (14, 1024) => merkle_roll_depth_size_apply_fn!(14, 1024, $bytes, $func, $($arg)*),
+            (14, 2448) => merkle_roll_depth_size_apply_fn!(14, 2448, $bytes, $func, $($arg)*),
+            (16, 64) => merkle_roll_depth_size_apply_fn!(16, 64, $bytes, $func, $($arg)*),
+            (16, 256) => merkle_roll_depth_size_apply_fn!(16, 256, $bytes, $func, $($arg)*),
+            (16, 1024) => merkle_roll_depth_size_apply_fn!(16, 1024, $bytes, $func, $($arg)*),
+            (16, 2448) => merkle_roll_depth_size_apply_fn!(16, 2448, $bytes, $func, $($arg)*),
+            (18, 64) => merkle_roll_depth_size_apply_fn!(18, 64, $bytes, $func, $($arg)*),
+            (18, 256) => merkle_roll_depth_size_apply_fn!(18, 256, $bytes, $func, $($arg)*),
+            (18, 1024) => merkle_roll_depth_size_apply_fn!(18, 1024, $bytes, $func, $($arg)*),
+            (18, 2448) => merkle_roll_depth_size_apply_fn!(18, 2448, $bytes, $func, $($arg)*),
             (20, 64) => merkle_roll_depth_size_apply_fn!(20, 64, $bytes, $func, $($arg)*),
-            (20, 128) => merkle_roll_depth_size_apply_fn!(20, 128, $bytes, $func, $($arg)*),
             (20, 256) => merkle_roll_depth_size_apply_fn!(20, 256, $bytes, $func, $($arg)*),
-            (20, 512) => merkle_roll_depth_size_apply_fn!(20, 512, $bytes, $func, $($arg)*),
             (20, 1024) => merkle_roll_depth_size_apply_fn!(20, 1024, $bytes, $func, $($arg)*),
             (20, 2448) => merkle_roll_depth_size_apply_fn!(20, 2448, $bytes, $func, $($arg)*),
-            // (21, 64) => merkle_roll_depth_size_apply_fn!(21, 64, $bytes, $func, $($arg)*),
-            // (21, 128) => merkle_roll_depth_size_apply_fn!(21, 128, $bytes, $func, $($arg)*),
-            // (21, 256) => merkle_roll_depth_size_apply_fn!(21, 256, $bytes, $func, $($arg)*),
-            // (21, 512) => merkle_roll_depth_size_apply_fn!(21, 512, $bytes, $func, $($arg)*),
-            // (21, 1024) => merkle_roll_depth_size_apply_fn!(21, 1024, $bytes, $func, $($arg)*),
-            // (21, 2448) => merkle_roll_depth_size_apply_fn!(21, 2448, $bytes, $func, $($arg)*),
-            // (22, 64) => merkle_roll_depth_size_apply_fn!(22, 64, $bytes, $func, $($arg)*),
-            // (22, 128) => merkle_roll_depth_size_apply_fn!(22, 128, $bytes, $func, $($arg)*),
-            // (22, 256) => merkle_roll_depth_size_apply_fn!(22, 256, $bytes, $func, $($arg)*),
-            // (22, 512) => merkle_roll_depth_size_apply_fn!(22, 512, $bytes, $func, $($arg)*),
-            // (22, 1024) => merkle_roll_depth_size_apply_fn!(22, 1024, $bytes, $func, $($arg)*),
-            // (22, 2448) => merkle_roll_depth_size_apply_fn!(22, 2448, $bytes, $func, $($arg)*),
-            // (23, 64) => merkle_roll_depth_size_apply_fn!(23, 64, $bytes, $func, $($arg)*),
-            // (23, 128) => merkle_roll_depth_size_apply_fn!(23, 128, $bytes, $func, $($arg)*),
-            // (23, 256) => merkle_roll_depth_size_apply_fn!(23, 256, $bytes, $func, $($arg)*),
-            // (23, 512) => merkle_roll_depth_size_apply_fn!(23, 512, $bytes, $func, $($arg)*),
-            // (23, 1024) => merkle_roll_depth_size_apply_fn!(23, 1024, $bytes, $func, $($arg)*),
-            // (23, 2448) => merkle_roll_depth_size_apply_fn!(23, 2448, $bytes, $func, $($arg)*),
-            // (24, 64) => merkle_roll_depth_size_apply_fn!(24, 64, $bytes, $func, $($arg)*),
-            // (24, 128) => merkle_roll_depth_size_apply_fn!(24, 128, $bytes, $func, $($arg)*),
-            // (24, 256) => merkle_roll_depth_size_apply_fn!(24, 256, $bytes, $func, $($arg)*),
-            // (24, 512) => merkle_roll_depth_size_apply_fn!(24, 512, $bytes, $func, $($arg)*),
-            // (24, 1024) => merkle_roll_depth_size_apply_fn!(24, 1024, $bytes, $func, $($arg)*),
-            // (24, 2448) => merkle_roll_depth_size_apply_fn!(24, 2448, $bytes, $func, $($arg)*),
+            (22, 64) => merkle_roll_depth_size_apply_fn!(22, 64, $bytes, $func, $($arg)*),
+            (22, 256) => merkle_roll_depth_size_apply_fn!(22, 256, $bytes, $func, $($arg)*),
+            (22, 1024) => merkle_roll_depth_size_apply_fn!(22, 1024, $bytes, $func, $($arg)*),
+            (22, 2448) => merkle_roll_depth_size_apply_fn!(22, 2448, $bytes, $func, $($arg)*),
             _ => {
                 msg!("Failed to apply {} on merkle roll with max depth {} and max buffer size {}", stringify!($func), $header.max_depth, $header.max_buffer_size);
                 None
@@ -206,7 +160,6 @@ pub mod gummyroll {
         max_buffer_size: u32,
         root: Node,
         leaf: Node,
-        proof: Vec<Node>,
         index: u32,
     ) -> ProgramResult {
         let mut merkle_roll_bytes = ctx.accounts.merkle_roll.try_borrow_mut_data()?;
@@ -220,6 +173,14 @@ pub mod gummyroll {
             max_buffer_size,
             &ctx.accounts.authority.key(),
         )?;
+
+        let mut proof = vec![];
+        for node in ctx.remaining_accounts.iter() {
+            proof.push(Node {
+                inner: node.key().to_bytes(),
+            });
+        }
+        assert_eq!(proof.len(), max_depth as usize);
 
         match merkle_roll_apply_fn!(
             header,
@@ -243,7 +204,6 @@ pub mod gummyroll {
         root: Node,
         previous_leaf: Node,
         new_leaf: Node,
-        proof: Vec<Node>,
         index: u32,
     ) -> ProgramResult {
         let mut merkle_roll_bytes = ctx.accounts.merkle_roll.try_borrow_mut_data()?;
@@ -251,6 +211,14 @@ pub mod gummyroll {
             merkle_roll_bytes.split_at_mut(size_of::<MerkleRollHeader>());
 
         let header = load_and_check_header(header_bytes, ctx.accounts.authority.key())?;
+
+        let mut proof = vec![];
+        for node in ctx.remaining_accounts.iter() {
+            proof.push(Node {
+                inner: node.key().to_bytes(),
+            });
+        }
+        assert_eq!(proof.len(), header.max_depth as usize);
 
         match merkle_roll_apply_fn!(
             header,
@@ -290,7 +258,6 @@ pub mod gummyroll {
         ctx: Context<Modify>,
         root: Node,
         leaf: Node,
-        proof: Vec<Node>,
         index: u32,
     ) -> ProgramResult {
         let mut merkle_roll_bytes = ctx.accounts.merkle_roll.try_borrow_mut_data()?;
@@ -298,6 +265,14 @@ pub mod gummyroll {
             merkle_roll_bytes.split_at_mut(size_of::<MerkleRollHeader>());
 
         let header = load_and_check_header(header_bytes, ctx.accounts.authority.key())?;
+
+        let mut proof = vec![];
+        for node in ctx.remaining_accounts.iter() {
+            proof.push(Node {
+                inner: node.key().to_bytes(),
+            });
+        }
+        assert_eq!(proof.len(), header.max_depth as usize);
 
         match merkle_roll_apply_fn!(
             header,

--- a/programs/gummyroll_crud/Cargo.toml
+++ b/programs/gummyroll_crud/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "gummyroll-crud"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "gummyroll_crud"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.22.1"
+gummyroll = { path = "../gummyroll", features = ["cpi"] }
+bytemuck = "1.8.0"

--- a/programs/gummyroll_crud/Xargo.toml
+++ b/programs/gummyroll_crud/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/gummyroll_crud/src/lib.rs
+++ b/programs/gummyroll_crud/src/lib.rs
@@ -1,0 +1,63 @@
+use anchor_lang::prelude::*;
+use gummyroll::program::Gummyroll;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[derive(Accounts)]
+pub struct Add<'info> {
+    #[account(mut)]
+    /// CHECK: unsafe
+    pub merkle_roll: UncheckedAccount<'info>,
+    pub owner: Signer<'info>,
+    pub gummyroll_program: Program<'info, Gummyroll>,
+}
+
+#[derive(Accounts)]
+pub struct Remove<'info> {
+    #[account(mut)]
+    /// CHECK: unsafe
+    pub merkle_roll: UncheckedAccount<'info>,
+    pub owner: Signer<'info>,
+    pub gummyroll_program: Program<'info, Gummyroll>,
+}
+
+#[derive(Accounts)]
+pub struct Transfer<'info> {
+    #[account(mut)]
+    /// CHECK: unsafe
+    pub merkle_roll: UncheckedAccount<'info>,
+    pub owner: Signer<'info>,
+    /// CHECK: This is safe because we don't read from or write to this account.
+    pub new_owner: UncheckedAccount<'info>,
+    pub gummyroll_program: Program<'info, Gummyroll>,
+}
+
+#[program]
+pub mod gummyroll_crud {
+
+    use super::*;
+
+    pub fn add(_ctx: Context<Add>, _message: Vec<u8>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn transfer(
+        _ctx: Context<Transfer>,
+        _root: [u8; 32],
+        _message: Vec<u8>,
+        _proof: Vec<[u8; 32]>,
+        _index: u32,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn remove(
+        _ctx: Context<Remove>,
+        _root: [u8; 32],
+        _message: Vec<u8>,
+        _proof: Vec<[u8; 32]>,
+        _index: u32,
+    ) -> Result<()> {
+        Ok(())
+    }
+}

--- a/programs/gummyroll_crud/src/lib.rs
+++ b/programs/gummyroll_crud/src/lib.rs
@@ -78,14 +78,29 @@ pub mod gummyroll_crud {
         gummyroll::cpi::replace_leaf(cpi_ctx, root_node, previous_leaf_node, leaf_node, index)
     }
 
-    pub fn remove(
-        _ctx: Context<Remove>,
-        _root: [u8; 32],
-        _message: Vec<u8>,
-        _proof: Vec<[u8; 32]>,
-        _index: u32,
+    pub fn remove<'info>(
+        ctx: Context<'_, '_, '_, 'info, Remove<'info>>,
+        root: [u8; 32],
+        message: Vec<u8>,
+        index: u32,
     ) -> Result<()> {
-        Ok(())
+        let gummyroll_program = ctx.accounts.gummyroll_program.to_account_info();
+        let merkle_roll = ctx.accounts.merkle_roll.to_account_info();
+        let owner = ctx.accounts.owner.to_account_info();
+        let cpi_ctx = CpiContext::new(
+            gummyroll_program,
+            gummyroll::cpi::accounts::Modify {
+                authority: owner.clone(),
+                merkle_roll,
+            },
+        )
+        .with_remaining_accounts(ctx.remaining_accounts.to_vec());
+        // It's important to synthesize the previous leaf ourselves, rather than to
+        // accept it as an arg, so that we can ensure the message is correct.
+        let previous_leaf_node = Node::new(get_message_hash(&owner, &message).to_bytes());
+        let leaf_node = Node::default();
+        let root_node = Node::new(root);
+        gummyroll::cpi::replace_leaf(cpi_ctx, root_node, previous_leaf_node, leaf_node, index)
     }
 }
 

--- a/tests/gummyroll_crud.ts
+++ b/tests/gummyroll_crud.ts
@@ -1,0 +1,170 @@
+import * as anchor from "@project-serum/anchor";
+import {
+  Keypair,
+  Transaction,
+  SystemProgram,
+  PublicKey,
+} from "@solana/web3.js";
+import { assert } from "chai";
+import { Gummyroll } from "../target/types/gummyroll";
+import { GummyrollCrud } from "../target/types/gummyroll_crud";
+import { Program } from "@project-serum/anchor";
+import { getMerkleRollAccountSize } from "./merkle-roll-serde";
+import { buildTree, getProofOfLeaf } from "./merkle-tree";
+
+// @ts-ignore
+const Gummyroll = anchor.workspace.Gummyroll as Program<Gummyroll>;
+// @ts-ignore
+const GummyrollCrud = anchor.workspace.GummyrollCrud as Program<GummyrollCrud>;
+
+const connection = GummyrollCrud.provider.connection;
+describe("Gummyroll CRUD program", () => {
+  const MAX_DEPTH = 14;
+  const MAX_SIZE = 64;
+  const requiredSpace = getMerkleRollAccountSize(MAX_DEPTH, MAX_SIZE);
+
+  let tree: ReturnType<typeof buildTree>;
+
+  async function appendMessage(message: string) {
+    const addIx = GummyrollCrud.instruction.add(Buffer.from(message), {
+      accounts: {
+        gummyrollProgram: Gummyroll.programId,
+        merkleRoll: merkleRollKeypair.publicKey,
+        owner: feePayerKeypair.publicKey,
+      },
+      signers: [feePayerKeypair],
+    });
+    await GummyrollCrud.provider.send(
+      new Transaction().add(addIx),
+      [feePayerKeypair],
+      {
+        commitment: "confirmed",
+      }
+    );
+  }
+  let feePayerKeypair: Keypair;
+  let merkleRollKeypair: Keypair;
+  beforeEach(async () => {
+    const leaves = Array(2 ** MAX_DEPTH).fill(Buffer.alloc(32));
+    tree = buildTree(leaves);
+
+    feePayerKeypair = Keypair.generate();
+    merkleRollKeypair = Keypair.generate();
+    await Gummyroll.provider.connection.confirmTransaction(
+      await Gummyroll.provider.connection.requestAirdrop(
+        feePayerKeypair.publicKey,
+        2e9
+      ),
+      "confirmed"
+    );
+    const allocGummyrollAccountIx = SystemProgram.createAccount({
+      fromPubkey: feePayerKeypair.publicKey,
+      newAccountPubkey: merkleRollKeypair.publicKey,
+      lamports:
+        await Gummyroll.provider.connection.getMinimumBalanceForRentExemption(
+          requiredSpace
+        ),
+      space: requiredSpace,
+      programId: Gummyroll.programId,
+    });
+    const initGummyrollTx = Gummyroll.instruction.initEmptyGummyroll(
+      MAX_DEPTH,
+      MAX_SIZE,
+      {
+        accounts: {
+          authority: feePayerKeypair.publicKey,
+          merkleRoll: merkleRollKeypair.publicKey,
+        },
+        signers: [feePayerKeypair],
+      }
+    );
+    const tx = new Transaction()
+      .add(allocGummyrollAccountIx)
+      .add(initGummyrollTx);
+    const initGummyRollTxId = await Gummyroll.provider.send(
+      tx,
+      [feePayerKeypair, merkleRollKeypair],
+      {
+        commitment: "confirmed",
+      }
+    );
+    assert(initGummyRollTxId, "Failed to initialize an empty Gummyroll");
+  });
+  describe("`Add` instruction", () => {
+    it("sanity check", async () => {
+      const firstTestMessage = "First test message";
+      await appendMessage(firstTestMessage);
+    });
+  });
+  describe("`Transfer` instruction", () => {
+    const message = "Message";
+    async function transferMessage(
+      newOwnerPubkey: PublicKey,
+      index: number,
+      config: { overrides?: { message?: string; signer?: Keypair } } = {}
+    ) {
+      const proofNodes = getProofOfLeaf(tree, index).map(({ node }) => node);
+      const signer = config.overrides?.signer;
+      const transferIx = GummyrollCrud.instruction.transfer(
+        Buffer.from(tree.root, 0, 32),
+        Buffer.from(config.overrides?.message ?? message),
+        proofNodes,
+        0,
+        {
+          accounts: {
+            gummyrollProgram: Gummyroll.programId,
+            merkleRoll: merkleRollKeypair.publicKey,
+            newOwner: newOwnerPubkey,
+            owner: feePayerKeypair.publicKey,
+          },
+          signers: [signer ?? feePayerKeypair],
+        }
+      );
+      const tx = new Transaction().add(transferIx);
+      await GummyrollCrud.provider.send(tx, [signer ?? feePayerKeypair], {
+        commitment: "confirmed",
+      });
+    }
+    beforeEach(async () => {
+      await appendMessage(message);
+    });
+    it("sanity check", async () => {
+      const newOwnerKeypair = Keypair.generate();
+      await transferMessage(newOwnerKeypair.publicKey, 0);
+    });
+  });
+  describe("`Remove` instruction", () => {
+    const message = "Message";
+    async function removeMessage(
+      index: number,
+      config: { overrides?: { message?: string; signer?: Keypair } } = {}
+    ) {
+      const proofNodes = getProofOfLeaf(tree, index).map(({ node }) => node);
+      const signer = config.overrides?.signer ?? feePayerKeypair;
+      const transferIx = GummyrollCrud.instruction.remove(
+        Buffer.from(tree.root, 0, 32),
+        Buffer.from(config.overrides?.message ?? message),
+        proofNodes,
+        0,
+        {
+          accounts: {
+            gummyrollProgram: Gummyroll.programId,
+            merkleRoll: merkleRollKeypair.publicKey,
+            owner: feePayerKeypair.publicKey,
+          },
+          signers: [signer],
+        }
+      );
+      const tx = new Transaction().add(transferIx);
+      await GummyrollCrud.provider.send(tx, [signer], {
+        commitment: "confirmed",
+      });
+    }
+    beforeEach(async () => {
+      await appendMessage(message);
+    });
+    it("sanity check", async () => {
+      await removeMessage(0);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds an on-chain program that can be used to:

* **append** a proof of inclusion for a given (owner, message) pair
* **transfer** an existing proof of inclusion for a given message to a new owner
* **remove** a proof of inclusion from the tree

The message can be an arbitrarily large vector of bytes.

To **transfer** or **remove**, the original owner must sign the transaction.

There exists protection from modifying the message during a transfer, or removing a proof without knowledge of the original message.