### PR TITLE
Test raw throughput against local validator

### DIFF
--- a/tests/merkle-tree.ts
+++ b/tests/merkle-tree.ts
@@ -5,7 +5,7 @@ import * as Collections from 'typescript-collections';
 const MAX_DEPTH = 20;
 let CACHE_EMPTY_NODE = new Map<number, Buffer>();
 
-type Tree = {
+export type Tree = {
     leaves: TreeNode[]
     root: Buffer,
 }


### PR DESCRIPTION
Local validator is very slow as of 1.9.6 (https://github.com/solana-labs/solana/issues/23376)

- Sleep 60s at beginning of testing suite to attempt to push more txs / slot into local validator.

- test flushing the buffer size out 2x, make sure happens