### PR TITLE
Updated contract to allow for >MAX_SIZE concurrency

### DIFF
--- a/programs/gummyroll/src/lib.rs
+++ b/programs/gummyroll/src/lib.rs
@@ -683,8 +683,6 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
         msg!("Rightmost Index: {}", self.rightmost_proof.index);
         msg!("Buffer Size: {}", self.buffer_size);
         msg!("Leaf Index: {}", index);
-        msg!("Old Leaf: {:?}", leaf.inner);
-        msg!("New Leaf: {:?}", new_leaf.inner);
         let mask: usize = MAX_BUFFER_SIZE - 1;
 
         for i in 0..self.buffer_size {
@@ -737,7 +735,6 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
         // Implement circular index addition
         loop {
             if !use_full_buffer && j == self.active_index {
-                msg!("Use partial buffer");
                 break;
             }
             j += 1;
@@ -749,11 +746,8 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
                 proof[critbit_index] = self.change_logs[j as usize].path[critbit_index];
             } else {
                 updated_leaf = self.change_logs[j as usize].get_leaf();
-                msg!("Buffer index {}, Updated leaf {}: {:?}", j, index, updated_leaf.inner);
             }
             if use_full_buffer && j == self.active_index {
-                msg!("Use full buffer");
-                msg!("{:?}", self.change_logs[j as usize].get_leaf());
                 break;
             }
         }

--- a/programs/gummyroll/src/lib.rs
+++ b/programs/gummyroll/src/lib.rs
@@ -754,6 +754,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
         sol_log_compute_units();
         let valid_root = recompute(updated_leaf, proof, index) == self.get_change_log().root;
         if updated_leaf != leaf || index > self.rightmost_proof.index {
+            // If the supplied root was not found in the queue, the instruction should fail if the leaf index changes
             if !use_full_buffer && valid_root && leaf == EMPTY && append_on_conflict {
                 return self.append(new_leaf);
             } else {

--- a/tests/gummyroll.ts
+++ b/tests/gummyroll.ts
@@ -7,12 +7,16 @@ import {
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
-import * as borsh from 'borsh';
+import * as borsh from "borsh";
 import { assert } from "chai";
 
 import { buildTree, hash, getProofOfLeaf, updateTree } from "./merkle-tree";
-import { decodeMerkleRoll, getMerkleRollAccountSize, OnChainMerkleRoll } from "./merkle-roll-serde";
-import { logTx } from './utils';
+import {
+  decodeMerkleRoll,
+  getMerkleRollAccountSize,
+  OnChainMerkleRoll,
+} from "./merkle-roll-serde";
+import { logTx } from "./utils";
 
 async function checkTxStatus(
   provider: anchor.Provider,
@@ -49,7 +53,7 @@ describe("gummyroll", () => {
   console.log("Created root using leaf pubkey: ", Uint8Array.from(leaves[0]));
   console.log("program id:", program.programId.toString());
 
- let listener = program.addEventListener("ChangeLogEvent", (event) => {
+  let listener = program.addEventListener("ChangeLogEvent", (event) => {
     updateTree(tree, Buffer.from(event.path[0].inner), event.index);
   });
 
@@ -75,7 +79,11 @@ describe("gummyroll", () => {
     const root = { inner: Array.from(tree.root) };
     const leaf = { inner: Array.from(leaves[0]) };
     const proof = getProofOfLeaf(tree, 0).map((node) => {
-      return { pubkey: new PublicKey(node.node), isSigner: false, isWritable: false };
+      return {
+        pubkey: new PublicKey(node.node),
+        isSigner: false,
+        isWritable: false,
+      };
     });
     const initGummyrollIx = await program.instruction.initGummyrollWithRoot(
       MAX_DEPTH,
@@ -89,7 +97,7 @@ describe("gummyroll", () => {
           authority: payer.publicKey,
         },
         signers: [payer],
-        remainingAccounts: proof
+        remainingAccounts: proof,
       }
     );
 
@@ -103,10 +111,16 @@ describe("gummyroll", () => {
     );
 
     let onChainMerkle = decodeMerkleRoll(merkleRoll.data);
-    
+
     // Check header bytes are set correctly
-    assert(onChainMerkle.header.maxDepth === MAX_DEPTH, `Max depth does not match ${onChainMerkle.header.maxDepth}, expected ${MAX_DEPTH}`);
-    assert(onChainMerkle.header.maxBufferSize === MAX_SIZE, `Max buffer size does not match ${onChainMerkle.header.maxBufferSize}, expected ${MAX_SIZE}`);
+    assert(
+      onChainMerkle.header.maxDepth === MAX_DEPTH,
+      `Max depth does not match ${onChainMerkle.header.maxDepth}, expected ${MAX_DEPTH}`
+    );
+    assert(
+      onChainMerkle.header.maxBufferSize === MAX_SIZE,
+      `Max buffer size does not match ${onChainMerkle.header.maxBufferSize}, expected ${MAX_SIZE}`
+    );
 
     assert(
       onChainMerkle.header.authority.equals(payer.publicKey),
@@ -165,7 +179,11 @@ describe("gummyroll", () => {
     const proof = getProofOfLeaf(tree, index);
 
     const nodeProof = proof.map((treeNode) => {
-      return { pubkey: new PublicKey(treeNode.node), isSigner: false, isWritable: false };
+      return {
+        pubkey: new PublicKey(treeNode.node),
+        isSigner: false,
+        isWritable: false,
+      };
     });
 
     const replaceLeafIx = program.instruction.replaceLeaf(
@@ -179,7 +197,7 @@ describe("gummyroll", () => {
           authority: payer.publicKey,
         },
         signers: [payer],
-        remainingAccounts: nodeProof
+        remainingAccounts: nodeProof,
       }
     );
 
@@ -210,12 +228,14 @@ describe("gummyroll", () => {
     let txList = [];
 
     const failedRoot = { inner: Array.from(tree.root) };
-    const failedLeaf = { inner: Array.from(tree.leaves[2].node) };
-    const failedProof = getProofOfLeaf(tree, 2).map(
-        (treeNode) => {
-            return { pubkey: new PublicKey(treeNode.node), isSigner: false, isWritable: false };
-        }
-    )
+    const failedLeaf = { inner: Array.from(tree.leaves[3 + MAX_SIZE].node) };
+    const failedProof = getProofOfLeaf(tree, 3 + MAX_SIZE).map((treeNode) => {
+      return {
+        pubkey: new PublicKey(treeNode.node),
+        isSigner: false,
+        isWritable: false,
+      };
+    });
 
     for (let i = 0; i < MAX_SIZE; i++) {
       const index = 3 + i;
@@ -229,7 +249,11 @@ describe("gummyroll", () => {
       changeArray.push({ newLeaf, index });
 
       const nodeProof = proof.map((treeNode) => {
-        return { pubkey: new PublicKey(treeNode.node), isSigner: false, isWritable: false };
+        return {
+          pubkey: new PublicKey(treeNode.node),
+          isSigner: false,
+          isWritable: false,
+        };
       });
 
       const insertOrAppendIx = await program.instruction.insertOrAppend(
@@ -257,9 +281,13 @@ describe("gummyroll", () => {
     await Promise.all(txList);
 
     // Compare on-chain & off-chain roots
-    const merkleRoll = decodeMerkleRoll((await program.provider.connection.getAccountInfo(
-      merkleRollKeypair.publicKey
-    )).data);
+    const merkleRoll = decodeMerkleRoll(
+      (
+        await program.provider.connection.getAccountInfo(
+          merkleRollKeypair.publicKey
+        )
+      ).data
+    );
     const onChainRoot =
       merkleRoll.roll.changeLogs[merkleRoll.roll.activeIndex].root.toBuffer();
 
@@ -268,12 +296,32 @@ describe("gummyroll", () => {
       "Updated on chain root does not match root of updated off chain tree"
     );
 
+    console.log("Sending a valid update despite the root being out of date");
+    const newLeaf = payer.publicKey.toBuffer();
+    let missingRootTx = await program.rpc.replaceLeaf(
+      failedRoot,
+      failedLeaf,
+      { inner: Array.from(newLeaf) },
+      3 + MAX_SIZE,
+      {
+        accounts: {
+          merkleRoll: merkleRollKeypair.publicKey,
+          authority: payer.publicKey,
+        },
+        signers: [payer],
+        remainingAccounts: failedProof,
+      }
+    );
+    await logTx(program.provider, missingRootTx);
+
+    console.log("Update should fail if repeated even if root is not in buffer");
+    let result;
     try {
-      await program.rpc.replaceLeaf(
+      let failedTx = await program.rpc.replaceLeaf(
         failedRoot,
         failedLeaf,
-        Buffer.alloc(32),
-        2,
+        { inner: Array.from(newLeaf) },
+        3 + MAX_SIZE,
         {
           accounts: {
             merkleRoll: merkleRollKeypair.publicKey,
@@ -283,11 +331,13 @@ describe("gummyroll", () => {
           remainingAccounts: failedProof,
         }
       );
-      console.log("Unexpected success");
-      assert(false);
+      await logTx(program.provider, failedTx);
+      result = false;
     } catch (e) {
-      console.log("Expected failure");
+      console.log("Instruction failed as expected");
+      result = true;
     }
+    assert(result);
   });
   it("Kill listeners", async () => {
     await program.removeEventListener(listener);


### PR DESCRIPTION
Changes:
- `recompute` is called after looping through the change log
- No hard failure in the case that root is not found in buffer
- Added additional safeties to make sure the state cannot get corrupted