### PR TITLE
Added PDA-based authorization scheme to the CRUD program

### DIFF
--- a/programs/gummyroll_crud/src/lib.rs
+++ b/programs/gummyroll_crud/src/lib.rs
@@ -9,15 +9,12 @@ pub struct CreateTree<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
     #[account(
-        init,
         seeds = [
             b"gummyroll-crud-authority-pda",
             merkle_roll.key().as_ref(),
             authority.key().as_ref(),
         ],
         bump,
-        payer = authority,
-        space = 0
     )]
     /// CHECK: This account is neither written to nor read from.
     pub authority_pda: UncheckedAccount<'info>,

--- a/programs/gummyroll_crud/src/lib.rs
+++ b/programs/gummyroll_crud/src/lib.rs
@@ -4,32 +4,92 @@ use gummyroll::{program::Gummyroll, Node};
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[derive(Accounts)]
-pub struct Add<'info> {
+#[instruction(max_depth: u32, max_buffer_size: u32)]
+pub struct CreateTree<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        init,
+        seeds = [
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key().as_ref(),
+            authority.key().as_ref(),
+        ],
+        bump,
+        payer = authority,
+        space = 0
+    )]
+    /// CHECK: This account is neither written to nor read from.
+    pub authority_pda: UncheckedAccount<'info>,
+    pub gummyroll_program: Program<'info, Gummyroll>,
     #[account(mut)]
     /// CHECK: unsafe
     pub merkle_roll: UncheckedAccount<'info>,
-    pub owner: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct Add<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        seeds = [
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key().as_ref(),
+            authority.key().as_ref(),
+        ],
+        bump,
+    )]
+    /// CHECK: This account is neither written to nor read from.
+    pub authority_pda: UncheckedAccount<'info>,
     pub gummyroll_program: Program<'info, Gummyroll>,
+    #[account(mut)]
+    /// CHECK: unsafe
+    pub merkle_roll: UncheckedAccount<'info>,
 }
 
 #[derive(Accounts)]
 pub struct Remove<'info> {
     #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        seeds = [
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key().as_ref(),
+            authority.key().as_ref(),
+        ],
+        bump,
+    )]
+    /// CHECK: This account is neither written to nor read from.
+    pub authority_pda: UncheckedAccount<'info>,
+    pub gummyroll_program: Program<'info, Gummyroll>,
+    #[account(mut)]
     /// CHECK: unsafe
     pub merkle_roll: UncheckedAccount<'info>,
-    pub owner: Signer<'info>,
-    pub gummyroll_program: Program<'info, Gummyroll>,
 }
 
 #[derive(Accounts)]
 pub struct Transfer<'info> {
+    /// CHECK: This account is neither written to nor read from.
+    pub authority: UncheckedAccount<'info>,
+    #[account(
+        seeds = [
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key().as_ref(),
+            authority.key().as_ref(),
+        ],
+        bump,
+    )]
+    /// CHECK: This account is neither written to nor read from.
+    pub authority_pda: UncheckedAccount<'info>,
+    pub gummyroll_program: Program<'info, Gummyroll>,
     #[account(mut)]
     /// CHECK: unsafe
     pub merkle_roll: UncheckedAccount<'info>,
+    #[account(mut)]
     pub owner: Signer<'info>,
-    /// CHECK: This is safe because we don't read from or write to this account.
+    /// CHECK: This account is neither written to nor read from.
     pub new_owner: UncheckedAccount<'info>,
-    pub gummyroll_program: Program<'info, Gummyroll>,
 }
 
 #[program]
@@ -37,18 +97,56 @@ pub mod gummyroll_crud {
 
     use super::*;
 
-    pub fn add(ctx: Context<Add>, message: Vec<u8>) -> Result<()> {
+    pub fn create_tree(
+        ctx: Context<CreateTree>,
+        max_depth: u32,
+        max_buffer_size: u32,
+    ) -> Result<()> {
         let gummyroll_program = ctx.accounts.gummyroll_program.to_account_info();
         let merkle_roll = ctx.accounts.merkle_roll.to_account_info();
-        let owner = ctx.accounts.owner.to_account_info();
-        let cpi_ctx = CpiContext::new(
+        let authority = ctx.accounts.authority.to_account_info();
+        let authority_pda = ctx.accounts.authority_pda.to_account_info();
+        let authority_pda_bump_seed = &[*ctx.bumps.get("authority_pda").unwrap()];
+        let seeds = &[
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key.as_ref(),
+            authority.key.as_ref(),
+            authority_pda_bump_seed,
+        ];
+        let authority_pda_signer = &[&seeds[..]];
+        let cpi_ctx = CpiContext::new_with_signer(
             gummyroll_program,
-            gummyroll::cpi::accounts::Modify {
-                authority: owner.clone(),
+            gummyroll::cpi::accounts::Initialize {
+                authority: authority_pda.clone(),
                 merkle_roll,
             },
+            authority_pda_signer,
         );
-        let leaf = Node::new(get_message_hash(&owner, &message).to_bytes());
+        gummyroll::cpi::init_empty_gummyroll(cpi_ctx, max_depth, max_buffer_size)
+    }
+
+    pub fn add(ctx: Context<Add>, message: Vec<u8>) -> Result<()> {
+        let authority = ctx.accounts.authority.to_account_info();
+        let authority_pda = ctx.accounts.authority_pda.to_account_info();
+        let gummyroll_program = ctx.accounts.gummyroll_program.to_account_info();
+        let merkle_roll = ctx.accounts.merkle_roll.to_account_info();
+        let authority_pda_bump_seed = &[*ctx.bumps.get("authority_pda").unwrap()];
+        let seeds = &[
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key.as_ref(),
+            authority.key.as_ref(),
+            authority_pda_bump_seed,
+        ];
+        let authority_pda_signer = &[&seeds[..]];
+        let cpi_ctx = CpiContext::new_with_signer(
+            gummyroll_program,
+            gummyroll::cpi::accounts::Modify {
+                authority: authority_pda.clone(),
+                merkle_roll,
+            },
+            authority_pda_signer,
+        );
+        let leaf = Node::new(get_message_hash(&authority, &message).to_bytes());
         gummyroll::cpi::append(cpi_ctx, leaf)
     }
 
@@ -58,16 +156,27 @@ pub mod gummyroll_crud {
         message: Vec<u8>,
         index: u32,
     ) -> Result<()> {
+        let authority = ctx.accounts.authority.to_account_info();
+        let authority_pda = ctx.accounts.authority_pda.to_account_info();
         let gummyroll_program = ctx.accounts.gummyroll_program.to_account_info();
         let merkle_roll = ctx.accounts.merkle_roll.to_account_info();
         let owner = ctx.accounts.owner.to_account_info();
         let new_owner = ctx.accounts.new_owner.to_account_info();
-        let cpi_ctx = CpiContext::new(
+        let authority_pda_bump_seed = &[*ctx.bumps.get("authority_pda").unwrap()];
+        let seeds = &[
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key.as_ref(),
+            authority.key.as_ref(),
+            authority_pda_bump_seed,
+        ];
+        let authority_pda_signer = &[&seeds[..]];
+        let cpi_ctx = CpiContext::new_with_signer(
             gummyroll_program,
             gummyroll::cpi::accounts::Modify {
-                authority: owner.clone(),
+                authority: authority_pda.clone(),
                 merkle_roll,
             },
+            authority_pda_signer,
         )
         .with_remaining_accounts(ctx.remaining_accounts.to_vec());
         // It's important to synthesize the previous leaf ourselves, rather than to
@@ -81,23 +190,32 @@ pub mod gummyroll_crud {
     pub fn remove<'info>(
         ctx: Context<'_, '_, '_, 'info, Remove<'info>>,
         root: [u8; 32],
-        message: Vec<u8>,
+        leaf_hash: [u8; 32],
         index: u32,
     ) -> Result<()> {
+        let authority = ctx.accounts.authority.to_account_info();
+        let authority_pda = ctx.accounts.authority_pda.to_account_info();
         let gummyroll_program = ctx.accounts.gummyroll_program.to_account_info();
         let merkle_roll = ctx.accounts.merkle_roll.to_account_info();
-        let owner = ctx.accounts.owner.to_account_info();
-        let cpi_ctx = CpiContext::new(
+        let authority_pda_bump_seed = &[*ctx.bumps.get("authority_pda").unwrap()];
+        let seeds = &[
+            b"gummyroll-crud-authority-pda",
+            merkle_roll.key.as_ref(),
+            authority.key.as_ref(),
+            authority_pda_bump_seed,
+        ];
+        let authority_pda_signer = &[&seeds[..]];
+        let cpi_ctx = CpiContext::new_with_signer(
             gummyroll_program,
             gummyroll::cpi::accounts::Modify {
-                authority: owner.clone(),
+                authority: authority_pda.clone(),
                 merkle_roll,
             },
+            authority_pda_signer,
         )
         .with_remaining_accounts(ctx.remaining_accounts.to_vec());
-        // It's important to synthesize the previous leaf ourselves, rather than to
-        // accept it as an arg, so that we can ensure the message is correct.
-        let previous_leaf_node = Node::new(get_message_hash(&owner, &message).to_bytes());
+
+        let previous_leaf_node = Node::new(leaf_hash);
         let leaf_node = Node::default();
         let root_node = Node::new(root);
         gummyroll::cpi::replace_leaf(cpi_ctx, root_node, previous_leaf_node, leaf_node, index)

--- a/programs/gummyroll_crud/src/lib.rs
+++ b/programs/gummyroll_crud/src/lib.rs
@@ -6,7 +6,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 #[derive(Accounts)]
 #[instruction(max_depth: u32, max_buffer_size: u32)]
 pub struct CreateTree<'info> {
-    #[account(mut)]
     pub authority: Signer<'info>,
     #[account(
         seeds = [
@@ -27,7 +26,6 @@ pub struct CreateTree<'info> {
 
 #[derive(Accounts)]
 pub struct Add<'info> {
-    #[account(mut)]
     pub authority: Signer<'info>,
     #[account(
         seeds = [
@@ -47,7 +45,6 @@ pub struct Add<'info> {
 
 #[derive(Accounts)]
 pub struct Remove<'info> {
-    #[account(mut)]
     pub authority: Signer<'info>,
     #[account(
         seeds = [
@@ -83,7 +80,6 @@ pub struct Transfer<'info> {
     #[account(mut)]
     /// CHECK: unsafe
     pub merkle_roll: UncheckedAccount<'info>,
-    #[account(mut)]
     pub owner: Signer<'info>,
     /// CHECK: This account is neither written to nor read from.
     pub new_owner: UncheckedAccount<'info>,


### PR DESCRIPTION
Presume that there is a keypair **BRAND** that manages _appends_ and _deletes_ from the tree.

Presume that each leaf encodes an **OWNER** that's allowed to _transfer_ an asset to another **OWNER**.

In this PR:

* Created an authority PDA owned by the CRUD program. The PDA encodes `(TREE_ADDRESS, BRAND)`.
* Added an ‘initialize empty tree’ instruction to the CRUD program. Creates a tree that only the authority PDA can write to.
* The CRUD program newly requires that BRAND is a signer on the add/remove instructions.
* The CRUD program newly requires that OWNER is a signer on the transfer instruction.