### PR TITLE
Add variable length proofs

### DIFF
--- a/programs/gummyroll/src/lib.rs
+++ b/programs/gummyroll/src/lib.rs
@@ -231,7 +231,6 @@ pub mod gummyroll {
         for node in ctx.remaining_accounts.iter() {
             proof.push(Node::new(node.key().to_bytes()));
         }
-        // assert_eq!(proof.len(), header.max_depth as usize);
 
         let id = ctx.accounts.merkle_roll.key();
         match merkle_roll_apply_fn!(
@@ -518,31 +517,11 @@ pub trait ZeroCopy: Pod {
     }
 }
 
-pub fn recompute_known_height<const MAX_DEPTH: usize>(
-    leaf: Node,
-    proof: Vec<Node>,
-    index: u32,
-    height: u32,
-) -> Node {
-    msg!("proof size: {}", proof.len());
-
-    let mut full_proof: [Node; MAX_DEPTH] = [Node::new([0; 32]); MAX_DEPTH];
-    full_proof.copy_from_slice(&proof);
-
-    for i in height..MAX_DEPTH as u32 {
-        full_proof[i as usize] = empty_node(i as u32);
-    }
-
-    return recompute(leaf, &full_proof, index);
-}
-
 fn fill_in_proof<const MAX_DEPTH: usize>(
     proof_vec: Vec<Node>,
     full_proof: &mut [Node; MAX_DEPTH],
     height: u32,
 ) {
-    msg!("proof size: {}", proof_vec.len());
-
     full_proof[..proof_vec.len()].copy_from_slice(&proof_vec);
 
     for i in height..MAX_DEPTH as u32 {
@@ -702,7 +681,6 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
             );
             None
         } else {
-            msg!("Height is: {}", self.get_height());
             let mut proof: [Node; MAX_DEPTH] = [Node::default(); MAX_DEPTH];
             fill_in_proof::<MAX_DEPTH>(proof_vec, &mut proof, self.get_height());
 

--- a/tests/continuous_gummyroll-test.ts
+++ b/tests/continuous_gummyroll-test.ts
@@ -12,7 +12,6 @@ import { assert } from "chai";
 
 import { buildTree, getProofOfLeaf, updateTree, Tree } from "./merkle-tree";
 import { decodeMerkleRoll, getMerkleRollAccountSize } from "./merkle-roll-serde";
-import { sleep } from "../deps/metaplex-program-library/metaplex/js/test/utils";
 import NodeWallet from "@project-serum/anchor/dist/cjs/nodewallet";
 
 // @ts-ignore

--- a/tests/gummyroll-test.ts
+++ b/tests/gummyroll-test.ts
@@ -18,7 +18,6 @@ import {
   getMerkleRollAccountSize,
 } from "./merkle-roll-serde";
 import { logTx } from "./utils";
-import { sleep } from "../deps/metaplex-program-library/metaplex/js/test/utils";
 
 // @ts-ignore
 const Gummyroll = anchor.workspace.Gummyroll as Program<Gummyroll>;
@@ -29,7 +28,6 @@ describe("gummyroll", () => {
   let offChainTree: Tree;
   let merkleRollKeypair: Keypair;
   let payer: Keypair;
-  let listener: number;
 
   const MAX_SIZE = 64;
   const MAX_DEPTH = 20;

--- a/tests/gummyroll_crud-test.ts
+++ b/tests/gummyroll_crud-test.ts
@@ -173,8 +173,8 @@ describe("Gummyroll CRUD program", () => {
       expect(
         merkleRollAccount.owner.equals(Gummyroll.programId),
         "Expected the tree to be owned by the Gummyroll program " +
-          `\`${Gummyroll.programId.toBase58()}\`. Was owned by ` +
-          `\`${merkleRollAccount.owner.toBase58()}\``
+        `\`${Gummyroll.programId.toBase58()}\`. Was owned by ` +
+        `\`${merkleRollAccount.owner.toBase58()}\``
       ).to.be.true;
       expect(merkleRollAccount.data.byteLength).to.equal(requiredSpace);
       const merkleRoll = decodeMerkleRoll(merkleRollAccount.data);
@@ -183,8 +183,8 @@ describe("Gummyroll CRUD program", () => {
       expect(
         merkleRoll.header.authority.equals(treeAuthorityPDA),
         "Expected the tree authority to be the authority PDA " +
-          `\`${treeAuthorityPDA.toBase58()}\`. Got ` +
-          `\`${merkleRoll.header.authority.toBase58()}\``
+        `\`${treeAuthorityPDA.toBase58()}\`. Got ` +
+        `\`${merkleRoll.header.authority.toBase58()}\``
       ).to.be.true;
     });
   });
@@ -209,7 +209,7 @@ describe("Gummyroll CRUD program", () => {
           false,
           "Nobody other than the tree admin should be able to add an asset to the tree"
         );
-      } catch {}
+      } catch { }
     });
     describe("having appended the first item", () => {
       const firstTestMessage = "First test message";
@@ -364,13 +364,13 @@ describe("Gummyroll CRUD program", () => {
           false,
           "Transaction should have failed since the message was modified"
         );
-      } catch {}
+      } catch { }
       const actualRoot = await getActualRoot(treeKeypair.publicKey);
       const expectedRoot = tree.root;
       expect(expectedRoot.compare(actualRoot)).to.equal(
         0,
         "The transaction should have failed because the message was " +
-          "modified, but never the less, the on-chain root hash changed."
+        "modified, but never the less, the on-chain root hash changed."
       );
     });
     it("fails if someone other than the owner tries to transfer an asset", async () => {
@@ -402,7 +402,7 @@ describe("Gummyroll CRUD program", () => {
           false,
           "Transaction should have failed since the signer was not the owner"
         );
-      } catch {}
+      } catch { }
     });
   });
   describe("`Remove` instruction", () => {
@@ -487,13 +487,13 @@ describe("Gummyroll CRUD program", () => {
           false,
           "Transaction should have failed since the leaf hash was wrong"
         );
-      } catch {}
+      } catch { }
       const actualRoot = await getActualRoot(treeKeypair.publicKey);
       const expectedRoot = tree.root;
       expect(expectedRoot.compare(actualRoot)).to.equal(
         0,
         "The transaction should have failed because the leaf hash was " +
-          "wrong, but never the less, the on-chain root hash changed."
+        "wrong, but never the less, the on-chain root hash changed."
       );
     });
     it("fails if someone other than the tree admin tries to remove a leaf", async () => {
@@ -518,7 +518,7 @@ describe("Gummyroll CRUD program", () => {
           false,
           "Transaction should have failed since the signer was not the owner"
         );
-      } catch {}
+      } catch { }
     });
   });
 });

--- a/tests/merkle-tree.ts
+++ b/tests/merkle-tree.ts
@@ -20,11 +20,11 @@ type TreeNode = {
 }
 
 const generateLeafNode = (seeds) => {
-  let leaf = Buffer.alloc(32);
-  for (const seed of seeds) {
-    leaf = Buffer.from(keccak_256.digest([...leaf, ...seed]));
-  }
-  return leaf;
+    let leaf = Buffer.alloc(32);
+    for (const seed of seeds) {
+        leaf = Buffer.from(keccak_256.digest([...leaf, ...seed]));
+    }
+    return leaf;
 };
 
 
@@ -98,7 +98,7 @@ export function buildTree(leaves: Buffer[]): Tree {
         }
         left.parent = parent;
         right.parent = parent;
-        nodes.enqueue(parent);    
+        nodes.enqueue(parent);
         seqNum++;
     }
 
@@ -111,12 +111,16 @@ export function buildTree(leaves: Buffer[]): Tree {
 /**
  * Takes a built Tree and returns the proof to leaf
  */
-export function getProofOfLeaf(tree: Tree, idx: number, verbose = false): TreeNode[] {
+export function getProofOfLeaf(tree: Tree, idx: number, minimizeProofHeight: boolean = false, treeHeight: number = -1, verbose = false): TreeNode[] {
     let proof: TreeNode[] = [];
 
     let node = tree.leaves[idx];
 
+    let height = 0;
     while (typeof node.parent !== 'undefined') {
+        if (minimizeProofHeight && height >= treeHeight) {
+            break;
+        }
         if (verbose) {
             console.log(`${node.level}: ${Uint8Array.from(node.node)}`);
         }
@@ -141,6 +145,7 @@ export function getProofOfLeaf(tree: Tree, idx: number, verbose = false): TreeNo
             }
         }
         node = parent;
+        height++;
     }
 
     return proof;


### PR DESCRIPTION
For a depth 20 tree, we don't need to submit a length 20 proof (20 extra public keys !!!)

Since the on-chain tree knows its own height (thanks to the `rightmost_proof`), we only need to submit proofs for the height of the subtree. So if tree is height 1, we need 1 key (the sibling)... same logic applies upwards.

This should make interfacing with the tree a little bit faster when its smaller, since easier to serialize & spam