### PR TITLE
🔨 Calculate tx size of appends empirically

### DIFF
--- a/tests/txLength.ts
+++ b/tests/txLength.ts
@@ -238,7 +238,10 @@ async function main() {
     }
 
     // Spec out how many append tx's can fit inside a single tx
-    for (let numAppends = 0; numAppends < 25; numAppends++) {
+    console.log(
+        `| Num Appends | Gummyroll Tx Size | Crud Tx Size |`
+    );
+    for (let numAppends = 1; numAppends < 25; numAppends++) {
         const rawSize = await getGummyrollMaxAppendTxSize(numAppends);
         const crudSize = await getGummyrollCrudMaxAppendTxSize(numAppends);
         console.log(

--- a/tests/txLength.ts
+++ b/tests/txLength.ts
@@ -11,6 +11,7 @@ import { IDL } from '../target/types/gummyroll';
 import { IDL as CrudIDL } from '../target/types/gummyroll_crud';
 import NodeWallet from '@project-serum/anchor/dist/cjs/nodewallet';
 import { GummyrollCrud } from '../target/types/gummyroll_crud';
+import * as crypto from 'crypto';
 
 const PROGRAM_ID = "GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD";
 
@@ -154,6 +155,74 @@ async function getMaxCrudTxSize(maxDepth: number): Promise<number> {
     return length
 }
 
+async function getGummyrollMaxAppendTxSize(numAppends: number): Promise<number> {
+    const merkleRollKeypair = Keypair.generate();
+
+    let tx = new Transaction()
+    for (let i = 0; i < numAppends; i++) {
+        tx = tx.add(
+            gummyroll.instruction.append(
+                {
+                    inner: Array.from(crypto.randomBytes(32))
+                },
+                {
+                    accounts: {
+                        merkleRoll: merkleRollKeypair.publicKey,
+                        authority: payer.publicKey,
+                    },
+                    signers: [payer],
+                }
+            ));
+    }
+
+    tx.feePayer = payer.publicKey;
+    tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    tx.sign(payer);
+
+    let length: number;
+    try {
+        const serialized = tx.serialize();
+        length = serialized.length;
+    } catch (e) {
+        length = -1;
+    }
+    return length
+}
+
+async function getGummyrollCrudMaxAppendTxSize(numAppends: number): Promise<number> {
+    const treeAdminKeypair = Keypair.generate();
+    const owner = Keypair.generate();
+    const merkleRollKeypair = Keypair.generate();
+    const authorityPda = Keypair.generate().publicKey;
+
+    let tx = new Transaction()
+    for (let i = 0; i < numAppends; i++) {
+        tx = tx.add(
+            gummyrollCrud.instruction.add(crypto.randomBytes(32), {
+                accounts: {
+                    authority: treeAdminKeypair.publicKey,
+                    authorityPda,
+                    gummyrollProgram: gummyroll.programId,
+                    merkleRoll: merkleRollKeypair.publicKey,
+                },
+                signers: [treeAdminKeypair],
+            }));
+    }
+
+    // tx.feePayer = payer.publicKey;
+    tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    tx.sign(treeAdminKeypair);
+
+    let length: number;
+    try {
+        const serialized = tx.serialize();
+        length = serialized.length;
+    } catch (e) {
+        length = -1;
+    }
+    return length
+}
+
 async function main() {
     console.log("| Max Depth | Max Leaves | Gummyroll Tx Size | Crud Tx Size |")
     for (let maxDepth = 14; maxDepth < 32; maxDepth++) {
@@ -164,7 +233,20 @@ async function main() {
         );
         if (rawSize < 0 && crudSize < 0) {
             console.log("No greater max depth is possible; Exiting")
-            return;
+            break;
+        }
+    }
+
+    // Spec out how many append tx's can fit inside a single tx
+    for (let numAppends = 0; numAppends < 25; numAppends++) {
+        const rawSize = await getGummyrollMaxAppendTxSize(numAppends);
+        const crudSize = await getGummyrollCrudMaxAppendTxSize(numAppends);
+        console.log(
+            `|${numAppends}|${rawSize.toString().padStart(4)}|${crudSize.toString().padStart(4)}|`
+        );
+        if (rawSize < 0 && crudSize < 0) {
+            console.log("No greater number of appends is possible; Exiting")
+            break;
         }
     }
 }


### PR DESCRIPTION
| Num Appends | Gummyroll Tx Size | Gummyroll CRUD Tx Size |
| --- | --- | -- |
|1| 243| 281|
|2| 288| 332|
|3| 333| 383|
|4| 378| 434|
|5| 423| 485|
|6| 468| 536|
|7| 513| 587|
|8| 558| 638|
|9| 603| 689|
|10| 648| 740|
|11| 693| 791|
|12| 738| 842|
|13| 783| 893|
|14| 828| 944|
|15| 873| 995|
|16| 918|1046|
|17| 963|1097|
|18|1008|1148|
|19|1053|1199|
|20|1098|  -1|
|21|1143|  -1|
|22|1188|  -1|
|23|  -1|  -1|