### PR TITLE
🛠 Refactor Plerkle to support multiple plugins 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ node_modules
 target
 *.so
 .vscode
+
+# Ignore vim swap files
+*.swp

--- a/plerkle/src/error.rs
+++ b/plerkle/src/error.rs
@@ -16,4 +16,7 @@ pub enum PlerkleError {
 
     #[error("Unable to Send Event to Stream ({msg})")]
     EventStreamError { msg: String },
+
+    #[error("Unable to access Connection. Error message: ({msg})")]
+    ConnectionNoneError { msg: String },
 }

--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -1,5 +1,10 @@
 use anchor_client::anchor_lang;
 use std::ops::Index;
+use std::borrow::{ BorrowMut};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+};
 
 extern crate redis;
 
@@ -30,116 +35,119 @@ mod program_ids {
     pubkeys!(AToken, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 }
 
-pub fn handle_transaction_info(
-    transaction_info: &ReplicaTransactionInfo,
-    redis_connection: &mut Connection
-) -> Result<()> {
+impl Plerkle {
+    pub fn handle_transaction_info(
+        &mut self,
+        transaction_info: &ReplicaTransactionInfo,
+    ) -> Result<()> {
 
-    if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
-        return Ok(());
-    }
-    // Handle Log PArsing
-    let keys = transaction_info.transaction.message().account_keys();
-    if keys.iter().any(|v| v == &program_ids::GummyRoll()) {
-        let maxlen = StreamMaxlen::Approx(55000);
-        let change_log_event = handle_change_log_event(&transaction_info);
-        if change_log_event.is_ok() {
-            change_log_event.unwrap().iter().for_each(|ev| {
-                let res: RedisResult<()> = redis_connection
-                    //.as_mut()
-                    //.unwrap()
-                    .xadd_maxlen("GM_CL", maxlen, "*", &[("data", ev)]);
-                if res.is_err() {
-                    error!("{}", res.err().unwrap());
-                } else {
-                    info!("Data Sent")
-                }
-            });
+        if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
+            return Ok(());
         }
-    }
-    // Handle Instruction Parsing
-    let instructions = Plerkle::order_instructions(&transaction_info);
-
-    for program_instruction in instructions {
-        match program_instruction {
-            (program, instruction) if program == program_ids::GummyRollCrud() => {
-                let maxlen = StreamMaxlen::Approx(5000);
-                let message = match gummyroll_crud::get_instruction_type(&instruction.data) {
-                    gummyroll_crud::InstructionName::CreateTree => {
-                        warn!("yo yo yo yo");
-                        let tree_id = keys.index(instruction.accounts[3] as usize);
-                        let auth = keys.index(instruction.accounts[0] as usize);
-                        let res: RedisResult<()> = redis_connection
-                            //.as_mut()
-                            //.unwrap()
-                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "create"), ("tree_id", &*tree_id.to_string()), ("authority", &*auth.to_string()) ]);
-                        if res.is_err() {
-                            error!("{}", res.err().unwrap());
-                        } else {
-                            info!("Data Sent")
-                        }
+        // Handle Log PArsing
+        let keys = transaction_info.transaction.message().account_keys();
+        if keys.iter().any(|v| v == &program_ids::GummyRoll()) {
+            let maxlen = StreamMaxlen::Approx(55000);
+            let change_log_event = handle_change_log_event(&transaction_info);
+            if change_log_event.is_ok() {
+                change_log_event.unwrap().iter().for_each(|ev| {
+                    let res: RedisResult<()> = self.redis_connection
+                        .as_mut()
+                        .unwrap()
+                        .xadd_maxlen("GM_CL", maxlen, "*", &[("data", ev)]);
+                    if res.is_err() {
+                        error!("{}", res.err().unwrap());
+                    } else {
+                        info!("Data Sent")
                     }
-                    gummyroll_crud::InstructionName::Add => {
-                        let data  = instruction.data[8..].to_owned();
-                        let data_buf = &mut data.as_slice();
-                        let add: gummyroll_crud::instruction::Add = gummyroll_crud::instruction::Add::deserialize(data_buf).unwrap();
-                        let tree_id = keys.index(instruction.accounts[3] as usize);
-                        let owner = keys.index(instruction.accounts[0] as usize);
-                        let hex_message = hex::encode(&add.message);
-                        let leaf = keccak::hashv(&[&owner.to_bytes(), add.message.as_slice()]);
-                        let res: RedisResult<()> = redis_connection
-                            //.as_mut()
-                            //.unwrap()
-                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "add"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()) ]);
-                        if res.is_err() {
-                            error!("{}", res.err().unwrap());
-                        } else {
-                            info!("Data Sent")
-                        }
-                    },
-                    gummyroll_crud::InstructionName::Transfer => {
-                        let data  = instruction.data[8..].to_owned();
-                        let data_buf = &mut data.as_slice();
-                        let add: gummyroll_crud::instruction::Transfer = gummyroll_crud::instruction::Transfer::deserialize(data_buf).unwrap();
-                        let tree_id = keys.index(instruction.accounts[3] as usize);
-                        let owner = keys.index(instruction.accounts[4] as usize);
-                        let new_owner = keys.index(instruction.accounts[5] as usize);
-                        let hex_message = hex::encode(&add.message);
-                        let leaf = keccak::hashv(&[&new_owner.to_bytes(), add.message.as_slice()]);
-                        let res: RedisResult<()> = redis_connection
-                            //.as_mut()
-                            //.unwrap()
-                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "tran"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()), ("new_owner", &*new_owner.to_string()) ]);
-                        if res.is_err() {
-                            error!("{}", res.err().unwrap());
-                        } else {
-                            info!("Data Sent")
-                        }
-                    }
-                    gummyroll_crud::InstructionName::Remove => {
-                        let data  = instruction.data[8..].to_owned();
-                        let data_buf = &mut data.as_slice();
-                        let remove: gummyroll_crud::instruction::Remove = gummyroll_crud::instruction::Remove::deserialize(data_buf).unwrap();
-                        let tree_id = keys.index(instruction.accounts[3] as usize);
-                        let owner = keys.index(instruction.accounts[0] as usize);
-                        let leaf = bs58::encode(&remove.leaf_hash).into_string();
-                        let res: RedisResult<()> = redis_connection
-                            //.unwrap()
-                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "rm"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", ""), ("owner", &*owner.to_string()) ]);
-                        if res.is_err() {
-                            error!("{}", res.err().unwrap());
-                        } else {
-                            info!("Data Sent")
-                        }
-                    }
-                    _ => {}
-                };
-
+                });
             }
-            _ => {}
-        };
+        }
+        // Handle Instruction Parsing
+        let instructions = Plerkle::order_instructions(&transaction_info);
+
+        for program_instruction in instructions {
+            match program_instruction {
+                (program, instruction) if program == program_ids::GummyRollCrud() => {
+                    let maxlen = StreamMaxlen::Approx(5000);
+                    let message = match gummyroll_crud::get_instruction_type(&instruction.data) {
+                        gummyroll_crud::InstructionName::CreateTree => {
+                            warn!("yo yo yo yo");
+                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                            let auth = keys.index(instruction.accounts[0] as usize);
+                            let res: RedisResult<()> = self.redis_connection
+                                .as_mut()
+                                .unwrap()
+                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "create"), ("tree_id", &*tree_id.to_string()), ("authority", &*auth.to_string()) ]);
+                            if res.is_err() {
+                                error!("{}", res.err().unwrap());
+                            } else {
+                                info!("Data Sent")
+                            }
+                        }
+                        gummyroll_crud::InstructionName::Add => {
+                            let data  = instruction.data[8..].to_owned();
+                            let data_buf = &mut data.as_slice();
+                            let add: gummyroll_crud::instruction::Add = gummyroll_crud::instruction::Add::deserialize(data_buf).unwrap();
+                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                            let owner = keys.index(instruction.accounts[0] as usize);
+                            let hex_message = hex::encode(&add.message);
+                            let leaf = keccak::hashv(&[&owner.to_bytes(), add.message.as_slice()]);
+                            let res: RedisResult<()> = self.redis_connection
+                                .as_mut()
+                                .unwrap()
+                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "add"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()) ]);
+                            if res.is_err() {
+                                error!("{}", res.err().unwrap());
+                            } else {
+                                info!("Data Sent")
+                            }
+                        },
+                        gummyroll_crud::InstructionName::Transfer => {
+                            let data  = instruction.data[8..].to_owned();
+                            let data_buf = &mut data.as_slice();
+                            let add: gummyroll_crud::instruction::Transfer = gummyroll_crud::instruction::Transfer::deserialize(data_buf).unwrap();
+                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                            let owner = keys.index(instruction.accounts[4] as usize);
+                            let new_owner = keys.index(instruction.accounts[5] as usize);
+                            let hex_message = hex::encode(&add.message);
+                            let leaf = keccak::hashv(&[&new_owner.to_bytes(), add.message.as_slice()]);
+                            let res: RedisResult<()> = self.redis_connection
+                                .as_mut()
+                                .unwrap()
+                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "tran"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()), ("new_owner", &*new_owner.to_string()) ]);
+                            if res.is_err() {
+                                error!("{}", res.err().unwrap());
+                            } else {
+                                info!("Data Sent")
+                            }
+                        }
+                        gummyroll_crud::InstructionName::Remove => {
+                            let data  = instruction.data[8..].to_owned();
+                            let data_buf = &mut data.as_slice();
+                            let remove: gummyroll_crud::instruction::Remove = gummyroll_crud::instruction::Remove::deserialize(data_buf).unwrap();
+                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                            let owner = keys.index(instruction.accounts[0] as usize);
+                            let leaf = bs58::encode(&remove.leaf_hash).into_string();
+                            let res: RedisResult<()> = self.redis_connection
+                                .as_mut()
+                                .unwrap()
+                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "rm"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", ""), ("owner", &*owner.to_string()) ]);
+                            if res.is_err() {
+                                error!("{}", res.err().unwrap());
+                            } else {
+                                info!("Data Sent")
+                            }
+                        }
+                        _ => {}
+                    };
+
+                }
+                _ => {}
+            };
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 define_redis_plugin!(

--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -1,35 +1,22 @@
 use anchor_client::anchor_lang;
-use std::borrow::{Borrow, BorrowMut};
-use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
 use std::ops::Index;
-use std::result::Iter;
 
 extern crate redis;
 
-use crate::error::PlerkleError;
+//use crate::error::PlerkleError;
 use crate::macros::*;
-use anchor_lang::Event;
 use redis::streams::StreamMaxlen;
 use redis::Commands;
-use redis::{Client, Connection, RedisResult};
-use regex::Regex;
+use redis::{Connection, RedisResult};
 use solana_geyser_plugin_interface::geyser_plugin_interface::{GeyserPluginError, ReplicaAccountInfoVersions, ReplicaBlockInfoVersions, ReplicaTransactionInfo, ReplicaTransactionInfoVersions, Result, SlotStatus};
-use std::str::FromStr;
 use solana_sdk::instruction::CompiledInstruction;
-use solana_sdk::message::AccountKeys;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::{keccak, pubkeys};
-use solana_sdk::transaction::Transaction;
 use anchor_client::anchor_lang::AnchorDeserialize;
-use hex;
+use solana_sdk::{keccak, pubkeys};
 use {
     log::*,
     solana_geyser_plugin_interface::geyser_plugin_interface::GeyserPlugin,
-    std::{fs::File, io::Read},
-    thiserror::Error,
 };
-use gummyroll_crud::InstructionName;
+//use gummyroll_crud::InstructionName;
 use crate::programs::gummy_roll::handle_change_log_event;
 
 mod program_ids {
@@ -43,267 +30,123 @@ mod program_ids {
     pubkeys!(AToken, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 }
 
-macro_rules! define_redis_plugin {
-    ($struct:ident, $name:literal, $func:ident) => {
-        #[derive(Default)]
-        pub struct $struct {
-            redis_connection: Option<Connection>,
-        }
+pub fn handle_transaction_info(
+    transaction_info: ReplicaTransactionInfo,
+    redis_connection: Option<Connection>
+) -> Result<()> {
 
-        impl $struct {
-            pub fn new() -> Self {
-                Self::default()
-            }
-
-            pub fn txn_contains_program<'a>(keys: AccountKeys, program: &Pubkey) -> bool {
-                keys.iter().find(|p| {
-                    let d = *p;
-                    d.eq(program)
-                }).is_some()
-            }
-
-            pub fn order_instructions(
-                transaction_info: &ReplicaTransactionInfo,
-            ) -> Vec<(Pubkey, CompiledInstruction)> {
-                let inner_ixs = transaction_info
-                    .transaction_status_meta
-                    .clone()
-                    .inner_instructions;
-                let outer_instructions = transaction_info.transaction.message().instructions();
-                let keys = transaction_info.transaction.message().account_keys();
-                let mut ordered_ixs: Vec<(Pubkey, CompiledInstruction)> = vec![];
-                if inner_ixs.is_some() {
-                    let inner_ix_list = inner_ixs.as_ref().unwrap().as_slice();
-                    for inner in inner_ix_list {
-                        let outer = outer_instructions.get(inner.index as usize).unwrap();
-                        let program_id = keys.index(outer.program_id_index as usize);
-                        ordered_ixs.push((*program_id, outer.to_owned()));
-                        for inner_ix_instance in &inner.instructions {
-                            let inner_program_id = keys.index(inner_ix_instance.program_id_index as usize);
-                            ordered_ixs.push((*inner_program_id, inner_ix_instance.to_owned()));
-                        }
-                    }
+    if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
+        return Ok(());
+    }
+    // Handle Log PArsing
+    let keys = transaction_info.transaction.message().account_keys();
+    if keys.iter().any(|v| v == &program_ids::GummyRoll()) {
+        let maxlen = StreamMaxlen::Approx(55000);
+        let change_log_event = handle_change_log_event(&transaction_info);
+        if change_log_event.is_ok() {
+            change_log_event.unwrap().iter().for_each(|ev| {
+                let res: RedisResult<()> = redis_connection
+                    .as_mut()
+                    .unwrap()
+                    .xadd_maxlen("GM_CL", maxlen, "*", &[("data", ev)]);
+                if res.is_err() {
+                    error!("{}", res.err().unwrap());
                 } else {
-                    for instruction in outer_instructions {
-                        let program_id = keys.index(instruction.program_id_index as usize);
-                        ordered_ixs.push((*program_id, instruction.to_owned()));
-                    }
+                    info!("Data Sent")
                 }
-                ordered_ixs.to_owned()
-            }
-        }
-
-        impl Debug for Plerkle {
-            fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
-                Ok(())
-            }
-        }
-
-        impl GeyserPlugin for Plerkle {
-            fn name(&self) -> &'static str {
-                $name
-            }
-
-            fn on_load(&mut self, config_file: &str) -> Result<()> {
-                solana_logger::setup_with_default("info");
-                info!(
-                    "Loading plugin {:?} from config_file {:?}",
-                    self.name(),
-                    config_file
-                );
-                let client = redis::Client::open("redis://redis/").unwrap();
-                self.redis_connection = client
-                    .get_connection()
-                    .map_err(|e| {
-                        error!("{}", e.to_string());
-                        GeyserPluginError::Custom(Box::new(PlerkleError::ConfigurationError {
-                            msg: e.to_string(),
-                        }))
-                    })
-                    .ok();
-                Ok(())
-            }
-
-            fn on_unload(&mut self) {
-                info!("Unloading plugin: {:?}", self.name());
-            }
-
-            fn update_account(
-                &mut self,
-                account: ReplicaAccountInfoVersions,
-                slot: u64,
-                _is_startup: bool,
-            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-                let ReplicaAccountInfoVersions::V0_0_1(accountv1) = account;
-                Ok(())
-            }
-
-            fn notify_end_of_startup(
-                &mut self,
-            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-                Ok(())
-            }
-
-            fn update_slot_status(
-                &mut self,
-                _slot: u64,
-                _parent: Option<u64>,
-                _status: SlotStatus,
-            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-                Ok(())
-            }
-
-            fn notify_transaction(
-                &mut self,
-                transaction: ReplicaTransactionInfoVersions,
-                slot: u64,
-            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-                match transaction {
-                    ReplicaTransactionInfoVersions::V0_0_1(transaction_info) => {
-                        if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
-                            return Ok(());
-                        }
-                        // Handle Log PArsing
-                        let keys = transaction_info.transaction.message().account_keys();
-                        if keys.iter().any(|v| v == &program_ids::GummyRoll()) {
-                            let maxlen = StreamMaxlen::Approx(55000);
-                            let change_log_event = handle_change_log_event(transaction_info);
-                            if change_log_event.is_ok() {
-                                change_log_event.unwrap().iter().for_each(|ev| {
-                                    let res: RedisResult<()> = self
-                                        .redis_connection
-                                        .as_mut()
-                                        .unwrap()
-                                        .xadd_maxlen("GM_CL", maxlen, "*", &[("data", ev)]);
-                                    if res.is_err() {
-                                        error!("{}", res.err().unwrap());
-                                    } else {
-                                        info!("Data Sent")
-                                    }
-                                });
-                            }
-                        }
-                        /// Handle Instruction Parsing
-                        let instructions = Plerkle::order_instructions(transaction_info);
-
-                        for program_instruction in instructions {
-                            match program_instruction {
-                                (program, instruction) if program == program_ids::GummyRollCrud() => {
-                                    let maxlen = StreamMaxlen::Approx(5000);
-                                    let message = match gummyroll_crud::get_instruction_type(&instruction.data) {
-                                        gummyroll_crud::InstructionName::CreateTree => {
-                                            warn!("yo yo yo yo");
-                                            let tree_id = keys.index(instruction.accounts[3] as usize);
-                                            let auth = keys.index(instruction.accounts[0] as usize);
-                                            let res: RedisResult<()> = self
-                                                .redis_connection
-                                                .as_mut()
-                                                .unwrap()
-                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "create"), ("tree_id", &*tree_id.to_string()), ("authority", &*auth.to_string()) ]);
-                                            if res.is_err() {
-                                                error!("{}", res.err().unwrap());
-                                            } else {
-                                                info!("Data Sent")
-                                            }
-                                        }
-                                        gummyroll_crud::InstructionName::Add => {
-                                            let data  = instruction.data[8..].to_owned();
-                                            let data_buf = &mut data.as_slice();
-                                            let add: gummyroll_crud::instruction::Add = gummyroll_crud::instruction::Add::deserialize(data_buf).unwrap();
-                                            let tree_id = keys.index(instruction.accounts[3] as usize);
-                                            let owner = keys.index(instruction.accounts[0] as usize);
-                                            let hex_message = hex::encode(&add.message);
-                                            let leaf = keccak::hashv(&[&owner.to_bytes(), add.message.as_slice()]);
-                                            let res: RedisResult<()> = self
-                                                .redis_connection
-                                                .as_mut()
-                                                .unwrap()
-                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "add"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()) ]);
-                                            if res.is_err() {
-                                                error!("{}", res.err().unwrap());
-                                            } else {
-                                                info!("Data Sent")
-                                            }
-                                        },
-                                        gummyroll_crud::InstructionName::Transfer => {
-                                            let data  = instruction.data[8..].to_owned();
-                                            let data_buf = &mut data.as_slice();
-                                            let add: gummyroll_crud::instruction::Transfer = gummyroll_crud::instruction::Transfer::deserialize(data_buf).unwrap();
-                                            let tree_id = keys.index(instruction.accounts[3] as usize);
-                                            let owner = keys.index(instruction.accounts[4] as usize);
-                                            let new_owner = keys.index(instruction.accounts[5] as usize);
-                                            let hex_message = hex::encode(&add.message);
-                                            let leaf = keccak::hashv(&[&new_owner.to_bytes(), add.message.as_slice()]);
-                                            let res: RedisResult<()> = self
-                                                .redis_connection
-                                                .as_mut()
-                                                .unwrap()
-                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "tran"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()), ("new_owner", &*new_owner.to_string()) ]);
-                                            if res.is_err() {
-                                                error!("{}", res.err().unwrap());
-                                            } else {
-                                                info!("Data Sent")
-                                            }
-                                        }
-                                        gummyroll_crud::InstructionName::Remove => {
-                                            let data  = instruction.data[8..].to_owned();
-                                            let data_buf = &mut data.as_slice();
-                                            let remove: gummyroll_crud::instruction::Remove = gummyroll_crud::instruction::Remove::deserialize(data_buf).unwrap();
-                                            let tree_id = keys.index(instruction.accounts[3] as usize);
-                                            let owner = keys.index(instruction.accounts[0] as usize);
-                                            let leaf = bs58::encode(&remove.leaf_hash).into_string();
-                                            let res: RedisResult<()> = self
-                                                .redis_connection
-                                                .as_mut()
-                                                .unwrap()
-                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "rm"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", ""), ("owner", &*owner.to_string()) ]);
-                                            if res.is_err() {
-                                                error!("{}", res.err().unwrap());
-                                            } else {
-                                                info!("Data Sent")
-                                            }
-                                        }
-                                        _ => {}
-                                    };
-
-                                }
-                                _ => {}
-                            };
-                        }
-                        Ok(())
-                    }
-                }
-            }
-
-
-            fn notify_block_metadata(
-                &mut self,
-                blockinfo: ReplicaBlockInfoVersions,
-            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-                match blockinfo {
-                    ReplicaBlockInfoVersions::V0_0_1(block) => {
-                        info!("Updating block: {:?}", block);
-                        // block.slot
-                    }
-                }
-                Ok(())
-            }
-
-            fn account_data_notifications_enabled(&self) -> bool {
-                true
-            }
-
-            fn transaction_notifications_enabled(&self) -> bool {
-                true
-            }
+            });
         }
     }
+    // Handle Instruction Parsing
+    let instructions = Plerkle::order_instructions(transaction_info);
+
+    for program_instruction in instructions {
+        match program_instruction {
+            (program, instruction) if program == program_ids::GummyRollCrud() => {
+                let maxlen = StreamMaxlen::Approx(5000);
+                let message = match gummyroll_crud::get_instruction_type(&instruction.data) {
+                    gummyroll_crud::InstructionName::CreateTree => {
+                        warn!("yo yo yo yo");
+                        let tree_id = keys.index(instruction.accounts[3] as usize);
+                        let auth = keys.index(instruction.accounts[0] as usize);
+                        let res: RedisResult<()> = redis_connection
+                            .as_mut()
+                            .unwrap()
+                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "create"), ("tree_id", &*tree_id.to_string()), ("authority", &*auth.to_string()) ]);
+                        if res.is_err() {
+                            error!("{}", res.err().unwrap());
+                        } else {
+                            info!("Data Sent")
+                        }
+                    }
+                    gummyroll_crud::InstructionName::Add => {
+                        let data  = instruction.data[8..].to_owned();
+                        let data_buf = &mut data.as_slice();
+                        let add: gummyroll_crud::instruction::Add = gummyroll_crud::instruction::Add::deserialize(data_buf).unwrap();
+                        let tree_id = keys.index(instruction.accounts[3] as usize);
+                        let owner = keys.index(instruction.accounts[0] as usize);
+                        let hex_message = hex::encode(&add.message);
+                        let leaf = keccak::hashv(&[&owner.to_bytes(), add.message.as_slice()]);
+                        let res: RedisResult<()> = redis_connection
+                            .as_mut()
+                            .unwrap()
+                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "add"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()) ]);
+                        if res.is_err() {
+                            error!("{}", res.err().unwrap());
+                        } else {
+                            info!("Data Sent")
+                        }
+                    },
+                    gummyroll_crud::InstructionName::Transfer => {
+                        let data  = instruction.data[8..].to_owned();
+                        let data_buf = &mut data.as_slice();
+                        let add: gummyroll_crud::instruction::Transfer = gummyroll_crud::instruction::Transfer::deserialize(data_buf).unwrap();
+                        let tree_id = keys.index(instruction.accounts[3] as usize);
+                        let owner = keys.index(instruction.accounts[4] as usize);
+                        let new_owner = keys.index(instruction.accounts[5] as usize);
+                        let hex_message = hex::encode(&add.message);
+                        let leaf = keccak::hashv(&[&new_owner.to_bytes(), add.message.as_slice()]);
+                        let res: RedisResult<()> = redis_connection
+                            .as_mut()
+                            .unwrap()
+                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "tran"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()), ("new_owner", &*new_owner.to_string()) ]);
+                        if res.is_err() {
+                            error!("{}", res.err().unwrap());
+                        } else {
+                            info!("Data Sent")
+                        }
+                    }
+                    gummyroll_crud::InstructionName::Remove => {
+                        let data  = instruction.data[8..].to_owned();
+                        let data_buf = &mut data.as_slice();
+                        let remove: gummyroll_crud::instruction::Remove = gummyroll_crud::instruction::Remove::deserialize(data_buf).unwrap();
+                        let tree_id = keys.index(instruction.accounts[3] as usize);
+                        let owner = keys.index(instruction.accounts[0] as usize);
+                        let leaf = bs58::encode(&remove.leaf_hash).into_string();
+                        let res: RedisResult<()> = redis_connection
+                            .as_mut()
+                            .unwrap()
+                            .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "rm"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", ""), ("owner", &*owner.to_string()) ]);
+                        if res.is_err() {
+                            error!("{}", res.err().unwrap());
+                        } else {
+                            info!("Data Sent")
+                        }
+                    }
+                    _ => {}
+                };
+
+            }
+            _ => {}
+        };
+    }
+    Ok(())
 }
 
 define_redis_plugin!(
     Plerkle,
     "plerkle",
-    msg
+    handle_transaction_info 
 );
 
 #[no_mangle]

--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -8,6 +8,7 @@ use std::result::Iter;
 extern crate redis;
 
 use crate::error::PlerkleError;
+use crate::macros::*;
 use anchor_lang::Event;
 use redis::streams::StreamMaxlen;
 use redis::Commands;
@@ -42,258 +43,268 @@ mod program_ids {
     pubkeys!(AToken, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 }
 
-#[derive(Default)]
-pub struct Plerkle {
-    redis_connection: Option<Connection>,
-}
-
-impl Plerkle {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn txn_contains_program<'a>(keys: AccountKeys, program: &Pubkey) -> bool {
-        keys.iter().find(|p| {
-            let d = *p;
-            d.eq(program)
-        }).is_some()
-    }
-
-    pub fn order_instructions(
-        transaction_info: &ReplicaTransactionInfo,
-    ) -> Vec<(Pubkey, CompiledInstruction)> {
-        let inner_ixs = transaction_info
-            .transaction_status_meta
-            .clone()
-            .inner_instructions;
-        let outer_instructions = transaction_info.transaction.message().instructions();
-        let keys = transaction_info.transaction.message().account_keys();
-        let mut ordered_ixs: Vec<(Pubkey, CompiledInstruction)> = vec![];
-        if inner_ixs.is_some() {
-            let inner_ix_list = inner_ixs.as_ref().unwrap().as_slice();
-            for inner in inner_ix_list {
-                let outer = outer_instructions.get(inner.index as usize).unwrap();
-                let program_id = keys.index(outer.program_id_index as usize);
-                ordered_ixs.push((*program_id, outer.to_owned()));
-                for inner_ix_instance in &inner.instructions {
-                    let inner_program_id = keys.index(inner_ix_instance.program_id_index as usize);
-                    ordered_ixs.push((*inner_program_id, inner_ix_instance.to_owned()));
-                }
-            }
-        } else {
-            for instruction in outer_instructions {
-                let program_id = keys.index(instruction.program_id_index as usize);
-                ordered_ixs.push((*program_id, instruction.to_owned()));
-            }
+macro_rules! define_redis_plugin {
+    ($struct:ident, $name:literal, $func:ident) => {
+        #[derive(Default)]
+        pub struct $struct {
+            redis_connection: Option<Connection>,
         }
-        ordered_ixs.to_owned()
-    }
-}
 
-impl Debug for Plerkle {
-    fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
-        Ok(())
-    }
-}
+        impl $struct {
+            pub fn new() -> Self {
+                Self::default()
+            }
 
-impl GeyserPlugin for Plerkle {
-    fn name(&self) -> &'static str {
-        "Plerkle"
-    }
+            pub fn txn_contains_program<'a>(keys: AccountKeys, program: &Pubkey) -> bool {
+                keys.iter().find(|p| {
+                    let d = *p;
+                    d.eq(program)
+                }).is_some()
+            }
 
-    fn on_load(&mut self, config_file: &str) -> Result<()> {
-        solana_logger::setup_with_default("info");
-        info!(
-            "Loading plugin {:?} from config_file {:?}",
-            self.name(),
-            config_file
-        );
-        let client = redis::Client::open("redis://redis/").unwrap();
-        self.redis_connection = client
-            .get_connection()
-            .map_err(|e| {
-                error!("{}", e.to_string());
-                GeyserPluginError::Custom(Box::new(PlerkleError::ConfigurationError {
-                    msg: e.to_string(),
-                }))
-            })
-            .ok();
-        Ok(())
-    }
-
-    fn on_unload(&mut self) {
-        info!("Unloading plugin: {:?}", self.name());
-    }
-
-    fn update_account(
-        &mut self,
-        account: ReplicaAccountInfoVersions,
-        slot: u64,
-        _is_startup: bool,
-    ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-        let ReplicaAccountInfoVersions::V0_0_1(accountv1) = account;
-        Ok(())
-    }
-
-    fn notify_end_of_startup(
-        &mut self,
-    ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-        Ok(())
-    }
-
-    fn update_slot_status(
-        &mut self,
-        _slot: u64,
-        _parent: Option<u64>,
-        _status: SlotStatus,
-    ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-        Ok(())
-    }
-
-    fn notify_transaction(
-        &mut self,
-        transaction: ReplicaTransactionInfoVersions,
-        slot: u64,
-    ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-        match transaction {
-            ReplicaTransactionInfoVersions::V0_0_1(transaction_info) => {
-                if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
-                    return Ok(());
-                }
-                // Handle Log PArsing
+            pub fn order_instructions(
+                transaction_info: &ReplicaTransactionInfo,
+            ) -> Vec<(Pubkey, CompiledInstruction)> {
+                let inner_ixs = transaction_info
+                    .transaction_status_meta
+                    .clone()
+                    .inner_instructions;
+                let outer_instructions = transaction_info.transaction.message().instructions();
                 let keys = transaction_info.transaction.message().account_keys();
-                if keys.iter().any(|v| v == &program_ids::GummyRoll()) {
-                    let maxlen = StreamMaxlen::Approx(55000);
-                    let change_log_event = handle_change_log_event(transaction_info);
-                    if change_log_event.is_ok() {
-                        change_log_event.unwrap().iter().for_each(|ev| {
-                            let res: RedisResult<()> = self
-                                .redis_connection
-                                .as_mut()
-                                .unwrap()
-                                .xadd_maxlen("GM_CL", maxlen, "*", &[("data", ev)]);
-                            if res.is_err() {
-                                error!("{}", res.err().unwrap());
-                            } else {
-                                info!("Data Sent")
-                            }
-                        });
+                let mut ordered_ixs: Vec<(Pubkey, CompiledInstruction)> = vec![];
+                if inner_ixs.is_some() {
+                    let inner_ix_list = inner_ixs.as_ref().unwrap().as_slice();
+                    for inner in inner_ix_list {
+                        let outer = outer_instructions.get(inner.index as usize).unwrap();
+                        let program_id = keys.index(outer.program_id_index as usize);
+                        ordered_ixs.push((*program_id, outer.to_owned()));
+                        for inner_ix_instance in &inner.instructions {
+                            let inner_program_id = keys.index(inner_ix_instance.program_id_index as usize);
+                            ordered_ixs.push((*inner_program_id, inner_ix_instance.to_owned()));
+                        }
+                    }
+                } else {
+                    for instruction in outer_instructions {
+                        let program_id = keys.index(instruction.program_id_index as usize);
+                        ordered_ixs.push((*program_id, instruction.to_owned()));
                     }
                 }
-                /// Handle Instruction Parsing
-                let instructions = Plerkle::order_instructions(transaction_info);
+                ordered_ixs.to_owned()
+            }
+        }
 
-                for program_instruction in instructions {
-                    match program_instruction {
-                        (program, instruction) if program == program_ids::GummyRollCrud() => {
-                            let maxlen = StreamMaxlen::Approx(5000);
-                            let message = match gummyroll_crud::get_instruction_type(&instruction.data) {
-                                gummyroll_crud::InstructionName::CreateTree => {
-                                    warn!("yo yo yo yo");
-                                    let tree_id = keys.index(instruction.accounts[3] as usize);
-                                    let auth = keys.index(instruction.accounts[0] as usize);
-                                    let res: RedisResult<()> = self
-                                        .redis_connection
-                                        .as_mut()
-                                        .unwrap()
-                                        .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "create"), ("tree_id", &*tree_id.to_string()), ("authority", &*auth.to_string()) ]);
-                                    if res.is_err() {
-                                        error!("{}", res.err().unwrap());
-                                    } else {
-                                        info!("Data Sent")
-                                    }
-                                }
-                                gummyroll_crud::InstructionName::Add => {
-                                    let data  = instruction.data[8..].to_owned();
-                                    let data_buf = &mut data.as_slice();
-                                    let add: gummyroll_crud::instruction::Add = gummyroll_crud::instruction::Add::deserialize(data_buf).unwrap();
-                                    let tree_id = keys.index(instruction.accounts[3] as usize);
-                                    let owner = keys.index(instruction.accounts[0] as usize);
-                                    let hex_message = hex::encode(&add.message);
-                                    let leaf = keccak::hashv(&[&owner.to_bytes(), add.message.as_slice()]);
-                                    let res: RedisResult<()> = self
-                                        .redis_connection
-                                        .as_mut()
-                                        .unwrap()
-                                        .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "add"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()) ]);
-                                    if res.is_err() {
-                                        error!("{}", res.err().unwrap());
-                                    } else {
-                                        info!("Data Sent")
-                                    }
-                                },
-                                gummyroll_crud::InstructionName::Transfer => {
-                                    let data  = instruction.data[8..].to_owned();
-                                    let data_buf = &mut data.as_slice();
-                                    let add: gummyroll_crud::instruction::Transfer = gummyroll_crud::instruction::Transfer::deserialize(data_buf).unwrap();
-                                    let tree_id = keys.index(instruction.accounts[3] as usize);
-                                    let owner = keys.index(instruction.accounts[4] as usize);
-                                    let new_owner = keys.index(instruction.accounts[5] as usize);
-                                    let hex_message = hex::encode(&add.message);
-                                    let leaf = keccak::hashv(&[&new_owner.to_bytes(), add.message.as_slice()]);
-                                    let res: RedisResult<()> = self
-                                        .redis_connection
-                                        .as_mut()
-                                        .unwrap()
-                                        .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "tran"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()), ("new_owner", &*new_owner.to_string()) ]);
-                                    if res.is_err() {
-                                        error!("{}", res.err().unwrap());
-                                    } else {
-                                        info!("Data Sent")
-                                    }
-                                }
-                                gummyroll_crud::InstructionName::Remove => {
-                                    let data  = instruction.data[8..].to_owned();
-                                    let data_buf = &mut data.as_slice();
-                                    let remove: gummyroll_crud::instruction::Remove = gummyroll_crud::instruction::Remove::deserialize(data_buf).unwrap();
-                                    let tree_id = keys.index(instruction.accounts[3] as usize);
-                                    let owner = keys.index(instruction.accounts[0] as usize);
-                                    let leaf = bs58::encode(&remove.leaf_hash).into_string();
-                                    let res: RedisResult<()> = self
-                                        .redis_connection
-                                        .as_mut()
-                                        .unwrap()
-                                        .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "rm"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", ""), ("owner", &*owner.to_string()) ]);
-                                    if res.is_err() {
-                                        error!("{}", res.err().unwrap());
-                                    } else {
-                                        info!("Data Sent")
-                                    }
-                                }
-                                _ => {}
-                            };
-
-                        }
-                        _ => {}
-                    };
-                }
+        impl Debug for Plerkle {
+            fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
                 Ok(())
             }
         }
-    }
+
+        impl GeyserPlugin for Plerkle {
+            fn name(&self) -> &'static str {
+                $name
+            }
+
+            fn on_load(&mut self, config_file: &str) -> Result<()> {
+                solana_logger::setup_with_default("info");
+                info!(
+                    "Loading plugin {:?} from config_file {:?}",
+                    self.name(),
+                    config_file
+                );
+                let client = redis::Client::open("redis://redis/").unwrap();
+                self.redis_connection = client
+                    .get_connection()
+                    .map_err(|e| {
+                        error!("{}", e.to_string());
+                        GeyserPluginError::Custom(Box::new(PlerkleError::ConfigurationError {
+                            msg: e.to_string(),
+                        }))
+                    })
+                    .ok();
+                Ok(())
+            }
+
+            fn on_unload(&mut self) {
+                info!("Unloading plugin: {:?}", self.name());
+            }
+
+            fn update_account(
+                &mut self,
+                account: ReplicaAccountInfoVersions,
+                slot: u64,
+                _is_startup: bool,
+            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                let ReplicaAccountInfoVersions::V0_0_1(accountv1) = account;
+                Ok(())
+            }
+
+            fn notify_end_of_startup(
+                &mut self,
+            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                Ok(())
+            }
+
+            fn update_slot_status(
+                &mut self,
+                _slot: u64,
+                _parent: Option<u64>,
+                _status: SlotStatus,
+            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                Ok(())
+            }
+
+            fn notify_transaction(
+                &mut self,
+                transaction: ReplicaTransactionInfoVersions,
+                slot: u64,
+            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                match transaction {
+                    ReplicaTransactionInfoVersions::V0_0_1(transaction_info) => {
+                        if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
+                            return Ok(());
+                        }
+                        // Handle Log PArsing
+                        let keys = transaction_info.transaction.message().account_keys();
+                        if keys.iter().any(|v| v == &program_ids::GummyRoll()) {
+                            let maxlen = StreamMaxlen::Approx(55000);
+                            let change_log_event = handle_change_log_event(transaction_info);
+                            if change_log_event.is_ok() {
+                                change_log_event.unwrap().iter().for_each(|ev| {
+                                    let res: RedisResult<()> = self
+                                        .redis_connection
+                                        .as_mut()
+                                        .unwrap()
+                                        .xadd_maxlen("GM_CL", maxlen, "*", &[("data", ev)]);
+                                    if res.is_err() {
+                                        error!("{}", res.err().unwrap());
+                                    } else {
+                                        info!("Data Sent")
+                                    }
+                                });
+                            }
+                        }
+                        /// Handle Instruction Parsing
+                        let instructions = Plerkle::order_instructions(transaction_info);
+
+                        for program_instruction in instructions {
+                            match program_instruction {
+                                (program, instruction) if program == program_ids::GummyRollCrud() => {
+                                    let maxlen = StreamMaxlen::Approx(5000);
+                                    let message = match gummyroll_crud::get_instruction_type(&instruction.data) {
+                                        gummyroll_crud::InstructionName::CreateTree => {
+                                            warn!("yo yo yo yo");
+                                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                                            let auth = keys.index(instruction.accounts[0] as usize);
+                                            let res: RedisResult<()> = self
+                                                .redis_connection
+                                                .as_mut()
+                                                .unwrap()
+                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "create"), ("tree_id", &*tree_id.to_string()), ("authority", &*auth.to_string()) ]);
+                                            if res.is_err() {
+                                                error!("{}", res.err().unwrap());
+                                            } else {
+                                                info!("Data Sent")
+                                            }
+                                        }
+                                        gummyroll_crud::InstructionName::Add => {
+                                            let data  = instruction.data[8..].to_owned();
+                                            let data_buf = &mut data.as_slice();
+                                            let add: gummyroll_crud::instruction::Add = gummyroll_crud::instruction::Add::deserialize(data_buf).unwrap();
+                                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                                            let owner = keys.index(instruction.accounts[0] as usize);
+                                            let hex_message = hex::encode(&add.message);
+                                            let leaf = keccak::hashv(&[&owner.to_bytes(), add.message.as_slice()]);
+                                            let res: RedisResult<()> = self
+                                                .redis_connection
+                                                .as_mut()
+                                                .unwrap()
+                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "add"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()) ]);
+                                            if res.is_err() {
+                                                error!("{}", res.err().unwrap());
+                                            } else {
+                                                info!("Data Sent")
+                                            }
+                                        },
+                                        gummyroll_crud::InstructionName::Transfer => {
+                                            let data  = instruction.data[8..].to_owned();
+                                            let data_buf = &mut data.as_slice();
+                                            let add: gummyroll_crud::instruction::Transfer = gummyroll_crud::instruction::Transfer::deserialize(data_buf).unwrap();
+                                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                                            let owner = keys.index(instruction.accounts[4] as usize);
+                                            let new_owner = keys.index(instruction.accounts[5] as usize);
+                                            let hex_message = hex::encode(&add.message);
+                                            let leaf = keccak::hashv(&[&new_owner.to_bytes(), add.message.as_slice()]);
+                                            let res: RedisResult<()> = self
+                                                .redis_connection
+                                                .as_mut()
+                                                .unwrap()
+                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "tran"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()), ("new_owner", &*new_owner.to_string()) ]);
+                                            if res.is_err() {
+                                                error!("{}", res.err().unwrap());
+                                            } else {
+                                                info!("Data Sent")
+                                            }
+                                        }
+                                        gummyroll_crud::InstructionName::Remove => {
+                                            let data  = instruction.data[8..].to_owned();
+                                            let data_buf = &mut data.as_slice();
+                                            let remove: gummyroll_crud::instruction::Remove = gummyroll_crud::instruction::Remove::deserialize(data_buf).unwrap();
+                                            let tree_id = keys.index(instruction.accounts[3] as usize);
+                                            let owner = keys.index(instruction.accounts[0] as usize);
+                                            let leaf = bs58::encode(&remove.leaf_hash).into_string();
+                                            let res: RedisResult<()> = self
+                                                .redis_connection
+                                                .as_mut()
+                                                .unwrap()
+                                                .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "rm"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", ""), ("owner", &*owner.to_string()) ]);
+                                            if res.is_err() {
+                                                error!("{}", res.err().unwrap());
+                                            } else {
+                                                info!("Data Sent")
+                                            }
+                                        }
+                                        _ => {}
+                                    };
+
+                                }
+                                _ => {}
+                            };
+                        }
+                        Ok(())
+                    }
+                }
+            }
 
 
-    fn notify_block_metadata(
-        &mut self,
-        blockinfo: ReplicaBlockInfoVersions,
-    ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-        match blockinfo {
-            ReplicaBlockInfoVersions::V0_0_1(block) => {
-                info!("Updating block: {:?}", block);
-                // block.slot
+            fn notify_block_metadata(
+                &mut self,
+                blockinfo: ReplicaBlockInfoVersions,
+            ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                match blockinfo {
+                    ReplicaBlockInfoVersions::V0_0_1(block) => {
+                        info!("Updating block: {:?}", block);
+                        // block.slot
+                    }
+                }
+                Ok(())
+            }
+
+            fn account_data_notifications_enabled(&self) -> bool {
+                true
+            }
+
+            fn transaction_notifications_enabled(&self) -> bool {
+                true
             }
         }
-        Ok(())
-    }
-
-    fn account_data_notifications_enabled(&self) -> bool {
-        true
-    }
-
-    fn transaction_notifications_enabled(&self) -> bool {
-        true
     }
 }
+
+define_redis_plugin!(
+    Plerkle,
+    "plerkle",
+    msg
+);
 
 #[no_mangle]
 #[allow(improper_ctypes_definitions)]

--- a/plerkle/src/lib.rs
+++ b/plerkle/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod macros;
 pub mod geyser_plugin_nft;
 mod programs;
 mod messenger;

--- a/plerkle/src/lib.rs
+++ b/plerkle/src/lib.rs
@@ -1,5 +1,5 @@
 mod error;
-mod macros;
+#[macro_use] mod macros;
 pub mod geyser_plugin_nft;
 mod programs;
 mod messenger;

--- a/plerkle/src/macros.rs
+++ b/plerkle/src/macros.rs
@@ -31,17 +31,7 @@ use {
 use gummyroll_crud::InstructionName;
 use crate::programs::gummy_roll::handle_change_log_event;
 
-mod program_ids {
-    #![allow(missing_docs)]
-
-    use solana_sdk::pubkeys;
-    pubkeys!(TokenMetadata, "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
-    pubkeys!(GummyRollCrud, "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
-    pubkeys!(GummyRoll, "GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD");
-    pubkeys!(Token, "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
-    pubkeys!(AToken, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
-}
-
+#[macro_use]
 pub mod macros {
     macro_rules! define_redis_plugin {
         ($struct:ident, $name:literal, $func:ident) => {
@@ -93,13 +83,13 @@ pub mod macros {
                 }
             }
 
-            impl Debug for Plerkle {
+            impl Debug for $struct {
                 fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
                     Ok(())
                 }
             }
 
-            impl GeyserPlugin for Plerkle {
+            impl GeyserPlugin for $struct {
                 fn name(&self) -> &'static str {
                     $name
                 }
@@ -160,6 +150,8 @@ pub mod macros {
                 ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
                     match transaction {
                         ReplicaTransactionInfoVersions::V0_0_1(transaction_info) => {
+                            $func(transaction_info, redis_connection);
+                            /*
                             if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
                                 return Ok(());
                             }
@@ -270,6 +262,7 @@ pub mod macros {
                                     _ => {}
                                 };
                             }
+                        */
                             Ok(())
                         }
                     }
@@ -299,5 +292,4 @@ pub mod macros {
             }
         }
     }
-
 }

--- a/plerkle/src/macros.rs
+++ b/plerkle/src/macros.rs
@@ -1,8 +1,12 @@
 use anchor_client::anchor_lang;
 use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
-use std::ops::Index;
+use std::{
+    fmt::{Debug, Formatter},
+    ops::Index,
+    rc::Rc,
+    cell::RefCell,
+};
 use std::result::Iter;
 
 extern crate redis;
@@ -152,7 +156,9 @@ pub mod macros {
                 ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
                     match transaction {
                         ReplicaTransactionInfoVersions::V0_0_1(transaction_info) => {
-                            match &self.redis_connection {
+                            self.$func(transaction_info);
+                            /*
+                            match self.redis_connection {
                                 Some(mut connection) => {
                                     $func(transaction_info, &mut connection);
                                 }
@@ -163,6 +169,7 @@ pub mod macros {
                                     }));
                                 }
                             }
+                            */
                             Ok(())
                         }
                     }

--- a/plerkle/src/macros.rs
+++ b/plerkle/src/macros.rs
@@ -1,0 +1,303 @@
+use anchor_client::anchor_lang;
+use std::borrow::{Borrow, BorrowMut};
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::ops::Index;
+use std::result::Iter;
+
+extern crate redis;
+
+use crate::error::PlerkleError;
+use anchor_lang::Event;
+use redis::streams::StreamMaxlen;
+use redis::Commands;
+use redis::{Client, Connection, RedisResult};
+use regex::Regex;
+use solana_geyser_plugin_interface::geyser_plugin_interface::{GeyserPluginError, ReplicaAccountInfoVersions, ReplicaBlockInfoVersions, ReplicaTransactionInfo, ReplicaTransactionInfoVersions, Result, SlotStatus};
+use std::str::FromStr;
+use solana_sdk::instruction::CompiledInstruction;
+use solana_sdk::message::AccountKeys;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{keccak, pubkeys};
+use solana_sdk::transaction::Transaction;
+use anchor_client::anchor_lang::AnchorDeserialize;
+use hex;
+use {
+    log::*,
+    solana_geyser_plugin_interface::geyser_plugin_interface::GeyserPlugin,
+    std::{fs::File, io::Read},
+    thiserror::Error,
+};
+use gummyroll_crud::InstructionName;
+use crate::programs::gummy_roll::handle_change_log_event;
+
+mod program_ids {
+    #![allow(missing_docs)]
+
+    use solana_sdk::pubkeys;
+    pubkeys!(TokenMetadata, "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
+    pubkeys!(GummyRollCrud, "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+    pubkeys!(GummyRoll, "GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD");
+    pubkeys!(Token, "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+    pubkeys!(AToken, "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+}
+
+pub mod macros {
+    macro_rules! define_redis_plugin {
+        ($struct:ident, $name:literal, $func:ident) => {
+            #[derive(Default)]
+            pub struct $struct {
+                redis_connection: Option<Connection>,
+            }
+
+            impl $struct {
+                pub fn new() -> Self {
+                    Self::default()
+                }
+
+                pub fn txn_contains_program<'a>(keys: AccountKeys, program: &Pubkey) -> bool {
+                    keys.iter().find(|p| {
+                        let d = *p;
+                        d.eq(program)
+                    }).is_some()
+                }
+
+                pub fn order_instructions(
+                    transaction_info: &ReplicaTransactionInfo,
+                ) -> Vec<(Pubkey, CompiledInstruction)> {
+                    let inner_ixs = transaction_info
+                        .transaction_status_meta
+                        .clone()
+                        .inner_instructions;
+                    let outer_instructions = transaction_info.transaction.message().instructions();
+                    let keys = transaction_info.transaction.message().account_keys();
+                    let mut ordered_ixs: Vec<(Pubkey, CompiledInstruction)> = vec![];
+                    if inner_ixs.is_some() {
+                        let inner_ix_list = inner_ixs.as_ref().unwrap().as_slice();
+                        for inner in inner_ix_list {
+                            let outer = outer_instructions.get(inner.index as usize).unwrap();
+                            let program_id = keys.index(outer.program_id_index as usize);
+                            ordered_ixs.push((*program_id, outer.to_owned()));
+                            for inner_ix_instance in &inner.instructions {
+                                let inner_program_id = keys.index(inner_ix_instance.program_id_index as usize);
+                                ordered_ixs.push((*inner_program_id, inner_ix_instance.to_owned()));
+                            }
+                        }
+                    } else {
+                        for instruction in outer_instructions {
+                            let program_id = keys.index(instruction.program_id_index as usize);
+                            ordered_ixs.push((*program_id, instruction.to_owned()));
+                        }
+                    }
+                    ordered_ixs.to_owned()
+                }
+            }
+
+            impl Debug for Plerkle {
+                fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
+                    Ok(())
+                }
+            }
+
+            impl GeyserPlugin for Plerkle {
+                fn name(&self) -> &'static str {
+                    $name
+                }
+
+                fn on_load(&mut self, config_file: &str) -> Result<()> {
+                    solana_logger::setup_with_default("info");
+                    info!(
+                        "Loading plugin {:?} from config_file {:?}",
+                        self.name(),
+                        config_file
+                    );
+                    let client = redis::Client::open("redis://redis/").unwrap();
+                    self.redis_connection = client
+                        .get_connection()
+                        .map_err(|e| {
+                            error!("{}", e.to_string());
+                            GeyserPluginError::Custom(Box::new(PlerkleError::ConfigurationError {
+                                msg: e.to_string(),
+                            }))
+                        })
+                        .ok();
+                    Ok(())
+                }
+
+                fn on_unload(&mut self) {
+                    info!("Unloading plugin: {:?}", self.name());
+                }
+
+                fn update_account(
+                    &mut self,
+                    account: ReplicaAccountInfoVersions,
+                    slot: u64,
+                    _is_startup: bool,
+                ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                    let ReplicaAccountInfoVersions::V0_0_1(accountv1) = account;
+                    Ok(())
+                }
+
+                fn notify_end_of_startup(
+                    &mut self,
+                ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                    Ok(())
+                }
+
+                fn update_slot_status(
+                    &mut self,
+                    _slot: u64,
+                    _parent: Option<u64>,
+                    _status: SlotStatus,
+                ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                    Ok(())
+                }
+
+                fn notify_transaction(
+                    &mut self,
+                    transaction: ReplicaTransactionInfoVersions,
+                    slot: u64,
+                ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                    match transaction {
+                        ReplicaTransactionInfoVersions::V0_0_1(transaction_info) => {
+                            if transaction_info.is_vote || transaction_info.transaction_status_meta.status.is_err() {
+                                return Ok(());
+                            }
+                            // Handle Log PArsing
+                            let keys = transaction_info.transaction.message().account_keys();
+                            if keys.iter().any(|v| v == &program_ids::GummyRoll()) {
+                                let maxlen = StreamMaxlen::Approx(55000);
+                                let change_log_event = handle_change_log_event(transaction_info);
+                                if change_log_event.is_ok() {
+                                    change_log_event.unwrap().iter().for_each(|ev| {
+                                        let res: RedisResult<()> = self
+                                            .redis_connection
+                                            .as_mut()
+                                            .unwrap()
+                                            .xadd_maxlen("GM_CL", maxlen, "*", &[("data", ev)]);
+                                        if res.is_err() {
+                                            error!("{}", res.err().unwrap());
+                                        } else {
+                                            info!("Data Sent")
+                                        }
+                                    });
+                                }
+                            }
+                            /// Handle Instruction Parsing
+                            let instructions = Plerkle::order_instructions(transaction_info);
+
+                            for program_instruction in instructions {
+                                match program_instruction {
+                                    (program, instruction) if program == program_ids::GummyRollCrud() => {
+                                        let maxlen = StreamMaxlen::Approx(5000);
+                                        let message = match gummyroll_crud::get_instruction_type(&instruction.data) {
+                                            gummyroll_crud::InstructionName::CreateTree => {
+                                                warn!("yo yo yo yo");
+                                                let tree_id = keys.index(instruction.accounts[3] as usize);
+                                                let auth = keys.index(instruction.accounts[0] as usize);
+                                                let res: RedisResult<()> = self
+                                                    .redis_connection
+                                                    .as_mut()
+                                                    .unwrap()
+                                                    .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "create"), ("tree_id", &*tree_id.to_string()), ("authority", &*auth.to_string()) ]);
+                                                if res.is_err() {
+                                                    error!("{}", res.err().unwrap());
+                                                } else {
+                                                    info!("Data Sent")
+                                                }
+                                            }
+                                            gummyroll_crud::InstructionName::Add => {
+                                                let data  = instruction.data[8..].to_owned();
+                                                let data_buf = &mut data.as_slice();
+                                                let add: gummyroll_crud::instruction::Add = gummyroll_crud::instruction::Add::deserialize(data_buf).unwrap();
+                                                let tree_id = keys.index(instruction.accounts[3] as usize);
+                                                let owner = keys.index(instruction.accounts[0] as usize);
+                                                let hex_message = hex::encode(&add.message);
+                                                let leaf = keccak::hashv(&[&owner.to_bytes(), add.message.as_slice()]);
+                                                let res: RedisResult<()> = self
+                                                    .redis_connection
+                                                    .as_mut()
+                                                    .unwrap()
+                                                    .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "add"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()) ]);
+                                                if res.is_err() {
+                                                    error!("{}", res.err().unwrap());
+                                                } else {
+                                                    info!("Data Sent")
+                                                }
+                                            },
+                                            gummyroll_crud::InstructionName::Transfer => {
+                                                let data  = instruction.data[8..].to_owned();
+                                                let data_buf = &mut data.as_slice();
+                                                let add: gummyroll_crud::instruction::Transfer = gummyroll_crud::instruction::Transfer::deserialize(data_buf).unwrap();
+                                                let tree_id = keys.index(instruction.accounts[3] as usize);
+                                                let owner = keys.index(instruction.accounts[4] as usize);
+                                                let new_owner = keys.index(instruction.accounts[5] as usize);
+                                                let hex_message = hex::encode(&add.message);
+                                                let leaf = keccak::hashv(&[&new_owner.to_bytes(), add.message.as_slice()]);
+                                                let res: RedisResult<()> = self
+                                                    .redis_connection
+                                                    .as_mut()
+                                                    .unwrap()
+                                                    .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "tran"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", &*hex_message), ("owner", &*owner.to_string()), ("new_owner", &*new_owner.to_string()) ]);
+                                                if res.is_err() {
+                                                    error!("{}", res.err().unwrap());
+                                                } else {
+                                                    info!("Data Sent")
+                                                }
+                                            }
+                                            gummyroll_crud::InstructionName::Remove => {
+                                                let data  = instruction.data[8..].to_owned();
+                                                let data_buf = &mut data.as_slice();
+                                                let remove: gummyroll_crud::instruction::Remove = gummyroll_crud::instruction::Remove::deserialize(data_buf).unwrap();
+                                                let tree_id = keys.index(instruction.accounts[3] as usize);
+                                                let owner = keys.index(instruction.accounts[0] as usize);
+                                                let leaf = bs58::encode(&remove.leaf_hash).into_string();
+                                                let res: RedisResult<()> = self
+                                                    .redis_connection
+                                                    .as_mut()
+                                                    .unwrap()
+                                                    .xadd_maxlen("GMC_OP", maxlen, "*", &[("op", "rm"), ("tree_id", &*tree_id.to_string()) , ("leaf", &*leaf.to_string()), ("msg", ""), ("owner", &*owner.to_string()) ]);
+                                                if res.is_err() {
+                                                    error!("{}", res.err().unwrap());
+                                                } else {
+                                                    info!("Data Sent")
+                                                }
+                                            }
+                                            _ => {}
+                                        };
+
+                                    }
+                                    _ => {}
+                                };
+                            }
+                            Ok(())
+                        }
+                    }
+                }
+
+
+                fn notify_block_metadata(
+                    &mut self,
+                    blockinfo: ReplicaBlockInfoVersions,
+                ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+                    match blockinfo {
+                        ReplicaBlockInfoVersions::V0_0_1(block) => {
+                            info!("Updating block: {:?}", block);
+                            // block.slot
+                        }
+                    }
+                    Ok(())
+                }
+
+                fn account_data_notifications_enabled(&self) -> bool {
+                    true
+                }
+
+                fn transaction_notifications_enabled(&self) -> bool {
+                    true
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Separate out Redis message bus logic, so that it's easier for 3rd parties to develop additional middleware.

Thoughts:
- Tried creating `listeners: Box<Vec<dyn Parser>>` field, but this does not implement `Send` trait... so I skipped thinking about thread safety & moved on to next option
- Define multiple plugins:
- - Gummyroll Plugin: writes Redis data about updating Gummyroll
- - Metadata Plugin: writes Redis data linking leaf hashes to pre-image (metadata)
- - 3rd party Plugin: extra logging

^ to make this really easy, I'm turning Plerkle into a `define_redis_plugin` macro, but we will see how that goes